### PR TITLE
Use OrderMap in GraphMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ debug = true
 fixedbitset = "0.1.0"
 quickcheck = { optional = true, version = "0.3" }
 itertools = "0.5"
+ordermap = { version = "0.2.1" }
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -26,6 +26,7 @@ use {
 use IntoWeightedEdge;
 use visit::IntoNodeIdentifiers;
 use graph::Graph;
+use graph::node_index;
 
 /// A `GraphMap` with undirected edges.
 ///
@@ -356,15 +357,13 @@ impl<N, E, Ty> GraphMap<N, E, Ty>
     {
         // assuming two successive iterations of the same hashmap produce the same order
         let mut gr = Graph::with_capacity(self.node_count(), self.edge_count());
-        // map N -> NodeIndex
-        let mut node_map = OrderMap::with_capacity(self.node_count());
         for (&node, _) in self.nodes.iter() {
-            node_map.insert(node, gr.add_node(node));
+            gr.add_node(node);
         }
         for ((a, b), edge_weight) in self.edges.into_iter() {
-            let ai = node_map[&a];
-            let bi = node_map[&b];
-            gr.add_edge(ai, bi, edge_weight);
+            let (ai, _, _) = self.nodes.get_pair_index(&a).unwrap();
+            let (bi, _, _) = self.nodes.get_pair_index(&b).unwrap();
+            gr.add_edge(node_index(ai), node_index(bi), edge_weight);
         }
         gr
     }

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1,4 +1,5 @@
-//! `GraphMap<N, E>` is an undirected graph where node values are mapping keys.
+//! `GraphMap<N, E, Ty>` is a graph datastructure where node values are mapping
+//! keys.
 
 use std::cmp::Ordering;
 use std::hash::{self, Hash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 
 extern crate fixedbitset;
 extern crate itertools;
+extern crate ordermap;
 
 #[doc(no_inline)]
 pub use graph::Graph;


### PR DESCRIPTION
This has multiple benefits. Not using a randomized order makes the
GraphMap's iteration order deterministic, which is in itself a good
thing.

Down the line we want to reform GraphMap and exploit the indexed access
in OrderMap.

Also improves `GraphMap::into_graph` to not need to create another
N → NodeIndex hashmap.

Fixes #80 