### PR TITLE
Implement PartialEq for algo::Cycle

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -523,7 +523,7 @@ impl<G> Iterator for MinSpanningTree<G>
 }
 
 /// An algorithm error: a cycle was found in the graph.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Cycle<N>(N);
 
 impl<N> Cycle<N> {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -491,6 +491,16 @@ fn test_toposort() {
 }
 
 #[test]
+fn test_toposort_eq() {
+    let mut g = Graph::<_,_>::new();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    g.add_edge(a, b, ());
+
+    assert_eq!(petgraph::algo::toposort(&g, None), Ok(vec![a, b]));
+}
+
+#[test]
 fn is_cyclic_directed() {
     let mut gr = Graph::<_,_>::new();
     let a = gr.add_node("A");


### PR DESCRIPTION
I added in the `PartialEq` autogenerated implementation in order to compare the return value of `toposort`.