### PR TITLE
Initial version of an adjacency matrix based graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,14 @@ itertools = { version = "0.5" }
 defmac = "0.1"
 
 [features]
-default = ["graphmap", "stable_graph"]
+default = ["graphmap", "stable_graph", "dense_graph"]
 graphmap = ["ordermap"]
 stable_graph = []
+dense_graph = []
 
 # For unstable features
 generate = []
 unstable = ["generate"]
 
 # feature flags for testing use only
-all = ["unstable", "quickcheck", "stable_graph", "graphmap"]
+all = ["unstable", "quickcheck", "dense_graph", "stable_graph", "graphmap"]

--- a/benches/dense_graph.rs
+++ b/benches/dense_graph.rs
@@ -7,7 +7,7 @@ use test::Bencher;
 use petgraph::prelude::*;
 
 use petgraph::{EdgeType};
-use petgraph::dense_graph::{DenseGraph, node_index};
+use petgraph::dense_graph::{DenseGraph, NodeIndex, node_index};
 
 /// An almost full set
 const FULL_A: &'static str = "
@@ -174,3 +174,34 @@ fn parse_graph<Ty: EdgeType>(s: &str) -> Graph<(), (), Ty>
     gr
 }
 
+#[bench]
+fn dense_graph_add_edges_from_root(bench: &mut Bencher)
+{
+    bench.iter(|| {
+        let mut gr: DenseGraph<(), ()> = DenseGraph::new();
+        let a = gr.add_node(());
+
+        for _ in 0..100 {
+            let b = gr.add_node(());
+            gr.add_edge(a, b, ());
+        }
+    });
+}
+
+#[bench]
+fn dense_graph_add_adjacent_edges(bench: &mut Bencher)
+{
+    bench.iter(|| {
+        let mut gr: DenseGraph<(), ()> = DenseGraph::new();
+        let mut prev: Option<NodeIndex> = None;
+        for _ in 0..100 {
+            let b = gr.add_node(());
+
+            if let Some(a) = prev {
+                gr.add_edge(a, b, ());
+            }
+
+            prev = Some(b);
+        }
+    });
+}

--- a/benches/dense_graph.rs
+++ b/benches/dense_graph.rs
@@ -1,0 +1,176 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use test::Bencher;
+use petgraph::prelude::*;
+
+use petgraph::{EdgeType};
+use petgraph::dense_graph::{DenseGraph, node_index};
+
+/// An almost full set
+const FULL_A: &'static str = "
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 0 1 1 1 0 1 
+ 1 1 1 1 1 1 1 1 1 1
+";
+
+const BIGGER: &'static str = "
+ 0 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 1 1 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 1 0 0 0 1 1 0 0 0 0 0 0 0 1 0 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+ 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
+ 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
+ 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
+ 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 1 0 1 1 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
+ 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
+ 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+ 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 1 1 0 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0
+ 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0
+ 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
+ 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0
+ 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0
+ 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
+ 0 1 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
+ 0 1 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
+ 0 1 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
+ 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
+ 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
+ 0 1 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
+";
+
+#[bench]
+fn full_edges_default(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(FULL_A);
+
+    bench.iter(|| a.edges(node_index(1)).count())
+}
+
+#[bench]
+fn full_edges_out(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(FULL_A);
+    bench.iter(|| a.edges_directed(node_index(1), Outgoing).count())
+}
+#[bench]
+fn full_edges_in(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(FULL_A);
+
+    bench.iter(|| a.edges_directed(node_index(1), Incoming).count())
+}
+
+#[bench]
+fn neighbors_default(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(FULL_A);
+
+    bench.iter(|| a.neighbors(node_index(1)).count())
+}
+
+#[bench]
+fn neighbors_out(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(FULL_A);
+    bench.iter(|| a.neighbors_directed(node_index(1), Outgoing).count())
+}
+#[bench]
+fn neighbors_in(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(FULL_A);
+
+    bench.iter(|| a.neighbors_directed(node_index(1), Incoming).count())
+}
+
+#[bench]
+fn sccs_dense_graph(bench: &mut Bencher)
+{
+    let a = parse_dense_graph::<Directed>(BIGGER);
+    bench.iter(|| petgraph::algo::kosaraju_scc(&a));
+}
+
+#[bench]
+fn sccs_graph(bench: &mut Bencher)
+{
+    let a = parse_graph::<Directed>(BIGGER);
+    bench.iter(|| petgraph::algo::kosaraju_scc(&a));
+}
+
+/// Parse a text adjacency matrix format into a directed graph
+fn parse_dense_graph<Ty: EdgeType>(s: &str) -> DenseGraph<(), (), Ty>
+{
+    let mut gr = DenseGraph::default();
+    let s = s.trim();
+    let lines = s.lines().filter(|l| !l.is_empty());
+    for (row, line) in lines.enumerate() {
+        for (col, word) in line.split(' ')
+                                .filter(|s| s.len() > 0)
+                                .enumerate()
+        {
+            let has_edge = word.parse::<i32>().unwrap();
+            assert!(has_edge == 0 || has_edge == 1);
+            if has_edge == 0 {
+                continue;
+            }
+            while col >= gr.node_count() || row >= gr.node_count() {
+                gr.add_node(());
+            }
+            gr.add_edge(node_index(row), node_index(col), ());
+        }
+    }
+    gr
+}
+
+/// Parse a text adjacency matrix format into a directed graph
+fn parse_graph<Ty: EdgeType>(s: &str) -> Graph<(), (), Ty>
+{
+    let mut gr = Graph::with_capacity(0, 0);
+    let s = s.trim();
+    let lines = s.lines().filter(|l| !l.is_empty());
+    for (row, line) in lines.enumerate() {
+        for (col, word) in line.split(' ')
+                                .filter(|s| s.len() > 0)
+                                .enumerate()
+        {
+            let has_edge = word.parse::<i32>().unwrap();
+            assert!(has_edge == 0 || has_edge == 1);
+            if has_edge == 0 {
+                continue;
+            }
+            while col >= gr.node_count() || row >= gr.node_count() {
+                gr.add_node(());
+            }
+            gr.update_edge(node_index(row), node_index(col), ());
+        }
+    }
+    gr
+}
+

--- a/src/dense_graph.rs
+++ b/src/dense_graph.rs
@@ -1,0 +1,741 @@
+use std::collections::hash_set;
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+use std::cmp;
+
+use dense_mapping::{DenseMapping, IdIterator};
+use fixedbitset::FixedBitSet;
+
+use {
+    Directed,
+    Direction,
+    EdgeType,
+    Incoming,
+    IntoWeightedEdge,
+    //Outgoing,
+    Undirected,
+};
+
+pub use graph::{
+    DefaultIx,
+    EdgeIndex,
+    IndexType,
+    NodeIndex,
+};
+
+use visit::{
+    GetAdjacencyMatrix,
+    GraphBase,
+    IntoNeighbors,
+    IntoNeighborsDirected,
+    IntoNodeIdentifiers,
+    NodeCount,
+    Visitable
+};
+
+pub use graph::{node_index, edge_index};
+
+type OptionVec<T> = Vec<Option<T>>;
+
+const INITIAL_RESIZE: usize = 10;
+
+fn ensure_len<T>(vec: &mut OptionVec<T>, min_len: usize) where T: Clone {
+    if vec.len() <= min_len {
+        let next_power_of_2_len = (min_len + 2) & !1;
+        vec.resize(cmp::max(next_power_of_2_len, INITIAL_RESIZE), None);
+    }
+}
+
+type Matrix = OptionVec<OptionVec<EdgeList>>;
+
+type EdgeList = hash_set::HashSet<usize>;
+type EdgeIter<'a> = hash_set::Iter<'a, usize>;
+
+pub struct DenseGraph<N, E, Ty = Directed, Ix = DefaultIx> {
+    matrix: Matrix,
+    nodes: DenseMapping<N>,
+    edges: DenseMapping<E>,
+    ty: PhantomData<Ty>,
+    ix: PhantomData<Ix>,
+}
+
+pub type DenseDiGraph<N, E, Ix = DefaultIx> = DenseGraph<N, E, Directed, Ix>;
+pub type DenseUnGraph<N, E, Ix = DefaultIx> = DenseGraph<N, E, Undirected, Ix>;
+
+impl<N, E, Ty, Ix> DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    /// Create a new `DenseGraph` with estimated capacity.
+    pub fn with_capacity(nodes: usize, edges: usize) -> Self {
+        DenseGraph {
+            matrix: Matrix::with_capacity(nodes),
+            nodes: DenseMapping::with_capacity(nodes),
+            edges: DenseMapping::with_capacity(edges),
+            ty: PhantomData,
+            ix: PhantomData,
+        }
+    }
+
+    /// Remove all nodes and edges
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+        self.edges.clear();
+        self.matrix.clear();
+    }
+
+    /// Return the number of nodes (vertices) in the graph.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn node_count(&self) -> usize {
+        self.nodes.size()
+    }
+
+    /// Return the number of edges in the graph.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn edge_count(&self) -> usize {
+        self.edges.size()
+    }
+
+    /// Whether the graph has directed edges or not.
+    #[inline]
+    pub fn is_directed(&self) -> bool {
+        Ty::is_directed()
+    }
+
+    /// Add a node (also called vertex) with associated data `weight` to the graph.
+    ///
+    /// Computes in **O(1)** time.
+    ///
+    /// Return the index of the new node.
+    ///
+    /// **Panics** if the Graph is at the maximum number of nodes for its index
+    /// type.
+    pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
+        let (id, _) = self.nodes.add(weight);
+
+        // Resize the matrix if necessary
+        ensure_len(&mut self.matrix, id);
+
+        NodeIndex::new(id)
+    }
+
+    /// Remove `a` from the graph if it exists, and return its weight.
+    /// If it doesn't exist in the graph, return `None`.
+    ///
+    /// The node index `a` is invalidated, but none other.
+    /// Edge indices are invalidated as they would be following the removal of
+    /// each edge with an endpoint in `a`.
+    ///
+    /// Computes in **O(V)** time, due to the removal of edges with other nodes.
+    pub fn remove_node(&mut self, ix: NodeIndex<Ix>) -> Option<N> {
+        let removed_node = self.nodes.remove(ix.index());
+
+        for node_neighbors in self.matrix.iter_mut().filter_map(|x| x.as_mut()) {
+            if ix.index() < node_neighbors.len() {
+                node_neighbors[ix.index()] = None;
+            }
+        }
+
+        self.matrix[ix.index()] = None;
+
+        removed_node
+    }
+
+    pub fn contains_node(&self, ix: NodeIndex<Ix>) -> bool {
+        self.nodes.exists(ix.index())
+    }
+
+    /// Add an edge from `a` to `b` to the graph, with its associated
+    /// data `weight`.
+    ///
+    /// Return the index of the new edge.
+    ///
+    /// Computes in **O(1)** time.
+    ///
+    /// **Panics** if any of the nodes don't exist.<br>
+    /// **Panics** if the Graph is at the maximum number of edges for its index
+    /// type.
+    ///
+    /// **Note:** `DenseGraph` allows adding parallel (“duplicate”) edges. If you want to avoid
+    /// this, use [`.update_edge(a, b, weight)`](#method.update_edge) instead.
+    pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
+        let (id, _) = self.edges.add(weight);
+
+        {
+            let is_directed = self.is_directed();
+
+            let mut insert_edge = |source: usize, target: usize| {
+                let ref mut neighbors = self.matrix[source];
+                if neighbors.is_none() {
+                    *neighbors = Some(Vec::new());
+                }
+
+                // Make sure node "source" has an entry for "target"
+                let mut neighbors = neighbors.as_mut().unwrap();
+                ensure_len(&mut neighbors, target);
+
+                let ref mut edges = neighbors[target];
+                if edges.is_none() {
+                    *edges = Some(EdgeList::new());
+                }
+                edges.as_mut().unwrap().insert(id);
+            };
+
+            insert_edge(a.index(), b.index());
+
+            if !is_directed {
+                insert_edge(b.index(), a.index());
+            }
+        }
+
+        EdgeIndex::new(id)
+    }
+
+    /// Return an iterator of all nodes with an edge starting from `a`.
+    ///
+    /// **Panics** if the node doesn't exist. Iterator element type is `NodeIndex<Ix>`.
+    pub fn neighbors(&self, ix: NodeIndex<Ix>) -> Neighbors<Ix> {
+        Neighbors::new(MatrixNeighbors::on_columns(&self.matrix, ix))
+    }
+
+    pub fn edges(&self, ix: NodeIndex<Ix>) -> Edges<Ix> {
+        Edges::new(MatrixNeighbors::on_columns(&self.matrix, ix))
+    }
+
+    /// Return an iterator of all neighbors that have an edge between them and
+    /// `a`, in the specified direction.
+    ///
+    /// - `Outgoing`: All edges from `a`.
+    /// - `Incoming`: All edges to `a`.
+    ///
+    /// **Panics** if the node doesn't exist. Iterator element type is `NodeIndex<Ix>`.
+    pub fn neighbors_directed(&self, ix: NodeIndex<Ix>, dir: Direction) -> Neighbors<Ix> {
+        if dir == Incoming {
+            Neighbors::new(MatrixNeighbors::on_rows(&self.matrix, ix))
+        } else {
+            self.neighbors(ix)
+        }
+    }
+
+    pub fn edges_directed(&self, ix: NodeIndex<Ix>, dir: Direction) -> Edges<Ix> {
+        if dir == Incoming {
+            Edges::new(MatrixNeighbors::on_rows(&self.matrix, ix))
+        } else {
+            self.edges(ix)
+        }
+    }
+
+    /// Extend the graph from an iterable of edges.
+    ///
+    /// Node weights `N` are set to default values.
+    /// Edge weights `E` may either be specified in the list,
+    /// or they are filled with default values.
+    ///
+    /// Nodes are inserted automatically to match the edges.
+    pub fn extend_with_edges<I>(&mut self, iterable: I)
+        where I: IntoIterator,
+              I::Item: IntoWeightedEdge<E>,
+              <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
+              N: Default,
+    {
+        let iter = iterable.into_iter();
+
+        for elt in iter {
+            let (source, target, weight) = elt.into_weighted_edge();
+            let (source, target) = (source.into(), target.into());
+            let nx = cmp::max(source, target);
+            while nx.index() >= self.node_count() {
+                self.add_node(N::default());
+            }
+            self.add_edge(source, target, weight);
+        }
+    }
+
+    /// Create a new `DenseGraph` from an iterable of edges.
+    ///
+    /// Node weights `N` are set to default values.
+    /// Edge weights `E` may either be specified in the list,
+    /// or they are filled with default values.
+    ///
+    /// Nodes are inserted automatically to match the edges.
+    pub fn from_edges<I>(iterable: I) -> Self
+        where I: IntoIterator,
+              I::Item: IntoWeightedEdge<E>,
+              <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
+              N: Default,
+    {
+        let mut g = Self::with_capacity(0, 0);
+        g.extend_with_edges(iterable);
+        g
+    }
+
+    /// Return `true` if the edge connecting `a` with `b` is contained in the graph.
+    pub fn contains_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
+        self.matrix[a.index()]
+            .as_ref()
+            .map(|ns| ns[b.index()].is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn node_indices(&self) -> NodeIndices<Ix> {
+        NodeIndices::new(self.nodes.iter_ids())
+    }
+}
+
+pub struct NodeIndices<'a, Ix>
+    where Ix: IndexType,
+{
+    iter: IdIterator<'a>,
+    ix: PhantomData<Ix>,
+}
+
+impl<'a, Ix> NodeIndices<'a, Ix>
+    where Ix: IndexType,
+{
+    fn new(iter: IdIterator<'a>) -> NodeIndices<'a, Ix> {
+        NodeIndices {
+            iter: iter,
+            ix: PhantomData,
+        }
+    }
+}
+
+impl<'a, Ix> Iterator for NodeIndices<'a, Ix>
+    where Ix: IndexType
+{
+    type Item = NodeIndex<Ix>;
+
+    fn next(&mut self) -> Option<NodeIndex<Ix>> {
+        self.iter.next().map(node_index)
+    }
+}
+
+impl<N, E, Ix> DenseGraph<N, E, Directed, Ix>
+    where N: Clone,
+          E: Clone,
+          Ix: IndexType,
+{
+    /// Create a new `DenseGraph` with directed edges.
+    ///
+    /// This is a convenience method. Use `DenseGraph::with_capacity` or `DenseGraph::default` for
+    /// a constructor that is generic in all the type parameters of `DenseGraph`.
+    pub fn new() -> Self {
+        DenseGraph::with_capacity(0, 0)
+    }
+}
+
+impl<N, E, Ix> DenseGraph<N, E, Undirected, Ix>
+    where N: Clone,
+          E: Clone,
+          Ix: IndexType
+{
+    /// Create a new `DenseGraph` with undirected edges.
+    ///
+    /// This is a convenience method. Use `DenseGraph::with_capacity` or `DenseGraph::default` for
+    /// a constructor that is generic in all the type parameters of `DenseGraph`.
+    pub fn new_undirected() -> Self {
+        DenseGraph::with_capacity(0, 0)
+    }
+
+    pub fn neighbors_undirected(&self, ix: NodeIndex<Ix>) -> Neighbors<Ix> {
+        self.neighbors(ix)
+    }
+}
+
+/// Create a new empty `DenseGraph`.
+impl<N, E, Ty, Ix> Default for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    fn default() -> Self {
+        Self::with_capacity(0, 0)
+    }
+}
+
+/// Index the `DenseGraph` by `NodeIndex` to access node weights.
+///
+/// **Panics** if the node doesn't exist.
+impl<N, E, Ty, Ix> Index<NodeIndex<Ix>> for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    type Output = N;
+    fn index(&self, index: NodeIndex<Ix>) -> &N {
+        &self.nodes[index.index()]
+    }
+}
+
+/// Index the `DenseGraph` by `NodeIndex` to access node weights.
+///
+/// **Panics** if the node doesn't exist.
+impl<N, E, Ty, Ix> IndexMut<NodeIndex<Ix>> for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    fn index_mut(&mut self, index: NodeIndex<Ix>) -> &mut N {
+        &mut self.nodes[index.index()]
+    }
+}
+
+/// Index the `DenseGraph` by `EdgeIndex` to access edge weights.
+///
+/// **Panics** if the edge doesn't exist.
+impl<N, E, Ty, Ix> Index<EdgeIndex<Ix>> for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    type Output = E;
+    fn index(&self, index: EdgeIndex<Ix>) -> &E {
+        &self.edges[index.index()]
+    }
+}
+
+/// Index the `DenseGraph` by `EdgeIndex` to access node weights.
+///
+/// **Panics** if the edge doesn't exist.
+impl<N, E, Ty, Ix> IndexMut<EdgeIndex<Ix>> for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    fn index_mut(&mut self, index: EdgeIndex<Ix>) -> &mut E {
+        &mut self.edges[index.index()]
+    }
+}
+
+/// The resulting cloned graph has the same graph indices as `self`.
+impl<N, E, Ty, Ix: IndexType> Clone for DenseGraph<N, E, Ty, Ix>
+    where N: Clone,
+          E: Clone
+{
+    fn clone(&self) -> Self {
+        DenseGraph {
+            nodes: self.nodes.clone(),
+            edges: self.edges.clone(),
+            matrix: self.matrix.clone(),
+            ty: self.ty,
+            ix: self.ix,
+        }
+    }
+
+    fn clone_from(&mut self, rhs: &Self) {
+        self.nodes.clone_from(&rhs.nodes);
+        self.edges.clone_from(&rhs.edges);
+        self.matrix.clone_from(&rhs.matrix);
+        self.ty = rhs.ty;
+    }
+}
+
+struct MatrixNeighbors<'a, Ix>
+    where Ix: IndexType
+{
+    matrix: &'a Matrix,
+    position: (usize, usize),
+    direction: MatrixDirection,
+    ix: PhantomData<Ix>,
+}
+
+struct MatrixPosition<'a> {
+    matrix: &'a Matrix,
+    position: (usize, usize),
+    direction: MatrixDirection,
+}
+
+impl<'a> MatrixPosition<'a> {
+    fn edges(&self) -> EdgeIter<'a> {
+        let (i, j) = self.position;
+        let ref neighbors = self.matrix[i].as_ref().unwrap();
+        neighbors[j].as_ref().unwrap().iter()
+    }
+
+    fn project(&self) -> usize {
+        let (i, j) = self.position;
+
+        match self.direction {
+            MatrixDirection::Rows    => i,
+            MatrixDirection::Columns => j,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Copy, Clone)]
+enum MatrixDirection {
+    Rows,
+    Columns,
+}
+
+#[derive(Eq, PartialEq)]
+enum MatrixNeighborsState {
+    Stop,
+    Continue,
+    Yield,
+}
+
+impl<'a, Ix> MatrixNeighbors<'a, Ix>
+    where Ix: IndexType
+{
+    fn new(matrix: &'a Matrix, position: (usize, usize), direction: MatrixDirection) -> MatrixNeighbors<'a, Ix> {
+        MatrixNeighbors {
+            matrix: matrix,
+            position: position,
+            direction: direction,
+            ix: PhantomData,
+        }
+    }
+
+    fn on_columns(matrix: &'a Matrix, ix: NodeIndex<Ix>) -> MatrixNeighbors<'a, Ix> {
+        let position = (ix.index(), 0);
+        let direction = MatrixDirection::Columns;
+
+        MatrixNeighbors::new(matrix, position, direction)
+    }
+
+    fn on_rows(matrix: &'a Matrix, ix: NodeIndex<Ix>) -> MatrixNeighbors<'a, Ix> {
+        let position = (0, ix.index());
+        let direction = MatrixDirection::Rows;
+
+        MatrixNeighbors::new(matrix, position, direction)
+    }
+}
+
+impl<'a, Ix> Iterator for MatrixNeighbors<'a, Ix>
+    where Ix: IndexType
+{
+    type Item = MatrixPosition<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (i, j) = self.position;
+
+            // check state before continuing
+            let state = {
+                if i >= self.matrix.len() {
+                    MatrixNeighborsState::Stop
+                } else if let Some(ref columns) = self.matrix[i] {
+                    if j >= columns.len() {
+                        MatrixNeighborsState::Stop
+                    } else if columns[j].is_some() {
+                        MatrixNeighborsState::Yield
+                    } else {
+                        MatrixNeighborsState::Continue
+                    }
+                } else if self.direction == MatrixDirection::Columns {
+                    MatrixNeighborsState::Stop
+                } else {
+                    MatrixNeighborsState::Continue
+                }
+            };
+
+            // advance unless at end
+            if state != MatrixNeighborsState::Stop {
+                let (ref mut y, ref mut x) = self.position;
+
+                let mut n = match self.direction {
+                    MatrixDirection::Rows    => y,
+                    MatrixDirection::Columns => x,
+                };
+
+                *n += 1;
+            }
+
+            // early return if there's a value for the current state
+            match state {
+                MatrixNeighborsState::Yield => {
+                    return Some(MatrixPosition {
+                        position: (i, j),
+                        matrix: &self.matrix,
+                        direction: self.direction,
+                    })
+                },
+
+                MatrixNeighborsState::Stop     => return None,
+                MatrixNeighborsState::Continue => {}
+            };
+        }
+    }
+}
+
+pub struct Neighbors<'a, Ix>
+    where Ix: IndexType,
+{
+    neighbors: MatrixNeighbors<'a, Ix>,
+}
+
+impl<'a, Ix> Neighbors<'a, Ix>
+    where Ix: IndexType
+{
+    fn new(neighbors: MatrixNeighbors<'a, Ix>) -> Neighbors<'a, Ix> {
+        Neighbors {
+            neighbors: neighbors,
+        }
+    }
+}
+
+impl<'a, Ix> Iterator for Neighbors<'a, Ix>
+    where Ix: IndexType
+{
+    type Item = NodeIndex<Ix>;
+
+    fn next(&mut self) -> Option<NodeIndex<Ix>> {
+        self.neighbors.next()
+            .map(|p| p.project())
+            .map(node_index)
+    }
+}
+
+pub struct Edges<'a, Ix>
+    where Ix: IndexType,
+{
+    neighbors: MatrixNeighbors<'a, Ix>,
+    iter: Option<EdgeIter<'a>>,
+}
+
+impl<'a, Ix> Edges<'a, Ix>
+    where Ix: IndexType,
+{
+    fn new(neighbors: MatrixNeighbors<'a, Ix>) -> Edges<'a, Ix> {
+        Edges {
+            neighbors: neighbors,
+            iter: None,
+        }
+    }
+}
+
+impl<'a, Ix> Edges<'a, Ix>
+    where Ix: IndexType,
+{
+    fn wrapped_next(&mut self) -> Option<&usize> {
+        self.iter = self.neighbors.next().map(|p| p.edges());
+
+        self.iter
+            .as_mut()
+            .and_then(|mut it| it.next())
+    }
+}
+
+impl<'a, Ix> Iterator for Edges<'a, Ix>
+    where Ix: IndexType,
+{
+    type Item = EdgeIndex<Ix>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let edge = if self.iter.is_none() {
+            self.wrapped_next()
+        } else {
+            let edge = self.iter.as_mut().unwrap().next();
+            edge.or_else(|| self.wrapped_next())
+        };
+
+        edge.map(|e| EdgeIndex::new(*e))
+    }
+}
+
+impl<N, E, Ty, Ix> GraphBase for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    type NodeId = NodeIndex<Ix>;
+    type EdgeId = EdgeIndex<Ix>;
+}
+
+impl<N, E, Ty, Ix> NodeCount for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone
+{
+    fn node_count(&self) -> usize {
+        (*self).node_count()
+    }
+}
+
+
+impl<N, E, Ty, Ix> GetAdjacencyMatrix for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone,
+{
+    type AdjMatrix = ();
+
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+    }
+
+    fn is_adjacent(&self, _: &Self::AdjMatrix, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
+        self.contains_edge(a, b)
+    }
+}
+
+impl<N, E, Ty, Ix> Visitable for DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone,
+{
+    type Map = FixedBitSet;
+
+    fn visit_map(&self) -> FixedBitSet {
+        FixedBitSet::with_capacity(self.node_count())
+    }
+
+    fn reset_map(&self, map: &mut Self::Map) {
+        map.clear();
+        map.grow(self.node_count());
+    }
+}
+
+impl<'a, N, E: 'a, Ty, Ix> IntoNeighbors for &'a DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone,
+{
+    type Neighbors = Neighbors<'a, Ix>;
+
+    fn neighbors(self, n: NodeIndex<Ix>) -> Neighbors<'a, Ix>
+    {
+        DenseGraph::neighbors(self, n)
+    }
+}
+
+impl<'a, N, E: 'a, Ix> IntoNeighborsDirected for &'a DenseGraph<N, E, Directed, Ix>
+    where Ix: IndexType,
+          N: Clone,
+          E: Clone,
+{
+    type NeighborsDirected = Neighbors<'a, Ix>;
+
+    fn neighbors_directed(self, n: NodeIndex<Ix>, d: Direction) -> Neighbors<'a, Ix>
+    {
+        DenseGraph::neighbors_directed(self, n, d)
+    }
+}
+
+impl<'a, N, E, Ty, Ix> IntoNodeIdentifiers for &'a DenseGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+          N: Clone,
+          E: Clone,
+{
+    type NodeIdentifiers = NodeIndices<'a, Ix>;
+
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        DenseGraph::node_indices(self)
+    }
+}
+

--- a/src/dense_graph.rs
+++ b/src/dense_graph.rs
@@ -41,8 +41,8 @@ const INITIAL_RESIZE: usize = 10;
 
 fn ensure_len<T>(vec: &mut OptionVec<T>, min_len: usize) where T: Clone {
     if vec.len() <= min_len {
-        let next_power_of_2_len = (min_len + 2) & !1;
-        vec.resize(cmp::max(next_power_of_2_len, INITIAL_RESIZE), None);
+        let next_len = min_len + 1;
+        vec.resize(cmp::max(next_len, INITIAL_RESIZE), None);
     }
 }
 

--- a/src/dense_graph.rs
+++ b/src/dense_graph.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_set;
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
+use std::cmp;
 
 use dense_mapping::{DenseMapping, IdIterator};
 use fixedbitset::FixedBitSet;

--- a/src/dense_mapping.rs
+++ b/src/dense_mapping.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::collections::HashSet;
 use std::mem;
 use std::ops::{Index, IndexMut};
@@ -23,8 +22,7 @@ impl<T: Clone> DenseMapping<T> {
         // Resize the vector to make sure we aren't out of bounds
         let elements_len = self.elements.len();
         if elements_len <= id {
-            let new_len = cmp::max(id + 1, elements_len) * 2;
-            self.elements.resize(new_len, None);
+            self.elements.resize(id + 1, None);
         }
 
         // Swap the previous value with the new value

--- a/src/dense_mapping.rs
+++ b/src/dense_mapping.rs
@@ -1,0 +1,168 @@
+use std::cmp;
+use std::collections::HashSet;
+use std::mem;
+use std::ops::{Index, IndexMut};
+
+#[derive(Clone)]
+pub struct DenseMapping<T> {
+    elements: Vec<Option<T>>,
+    ids: IdGenerator,
+}
+
+impl<T: Clone> DenseMapping<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        DenseMapping {
+            elements: Vec::with_capacity(capacity),
+            ids: IdGenerator::new(),
+        }
+    }
+
+    pub fn add(&mut self, element: T) -> (usize, Option<T>) {
+        let id: usize = self.ids.add();
+
+        // Resize the vector to make sure we aren't out of bounds
+        let elements_len = self.elements.len();
+        if elements_len <= id {
+            let new_len = cmp::max(id + 1, elements_len) * 2;
+            self.elements.resize(new_len, None);
+        }
+
+        // Swap the previous value with the new value
+        let previous_element = mem::replace(&mut self.elements[id], Some(element));
+
+        (id, previous_element)
+    }
+
+    pub fn remove(&mut self, id: usize) -> Option<T> {
+        let element_exists = self.ids.exists(id);
+
+        self.ids.remove(id);
+
+        if element_exists {
+            let old_weight = self.elements[id].clone();
+            self.elements[id] = None;
+            old_weight
+        } else {
+            None
+        }
+    }
+
+    pub fn exists(&self, id: usize) -> bool {
+        self.ids.exists(id)
+    }
+
+    pub fn size(&self) -> usize {
+        self.ids.size()
+    }
+
+    pub fn clear(&mut self) {
+        self.elements.clear();
+        self.ids.clear();
+    }
+
+    pub fn iter_ids(&self) -> IdIterator {
+        self.ids.iter()
+    }
+}
+
+impl<T: Clone> Index<usize> for DenseMapping<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &T {
+        self.elements[index].as_ref().unwrap()
+    }
+}
+
+impl<T: Clone> IndexMut<usize> for DenseMapping<T> {
+    fn index_mut(&mut self, index: usize) -> &mut T {
+        self.elements[index].as_mut().unwrap()
+    }
+}
+
+#[derive(Clone)]
+struct IdGenerator {
+    upper_bound: usize,
+    removed_ids: HashSet<usize>,
+}
+
+impl IdGenerator {
+    fn new() -> IdGenerator {
+        IdGenerator {
+            upper_bound: 0,
+            removed_ids: HashSet::new(),
+        }
+    }
+
+    fn add(&mut self) -> usize {
+        if !self.removed_ids.is_empty() {
+            let id = self.removed_ids.iter().next().unwrap().clone();
+            self.removed_ids.remove(&id);
+            id
+        } else {
+            let id = self.upper_bound;
+            self.upper_bound = self.upper_bound + 1;
+            id
+        }
+    }
+
+    fn remove(&mut self, id: usize) {
+        if id < self.upper_bound {
+            self.removed_ids.insert(id);
+        }
+    }
+
+    fn exists(&self, id: usize) -> bool {
+        id < self.upper_bound && !self.removed_ids.contains(&id)
+    }
+
+    fn size(&self) -> usize {
+        self.upper_bound - self.removed_ids.len()
+    }
+
+    fn clear(&mut self) {
+        *self = IdGenerator::new();
+    }
+
+    fn iter(&self) -> IdIterator {
+        IdIterator::new(self)
+    }
+}
+
+pub struct IdIterator<'a> {
+    ids: &'a IdGenerator,
+    current: Option<usize>,
+}
+
+impl<'a> IdIterator<'a> {
+    fn new(ids: &'a IdGenerator) -> IdIterator<'a> {
+        IdIterator {
+            ids: ids,
+            current: None,
+        }
+    }
+}
+
+impl<'a> Iterator for IdIterator<'a> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // initialize / advance
+        if self.current.is_none() {
+            self.current = Some({
+                (0..self.ids.upper_bound)
+                    .skip_while(|id| self.ids.removed_ids.contains(&id))
+                    .next()
+                    .unwrap_or(self.ids.upper_bound)
+            });
+        } else {
+            let mut current = self.current.as_mut().unwrap();
+            *current += 1;
+        }
+
+        let current = self.current.unwrap();
+        if current < self.ids.upper_bound {
+            Some(current)
+        } else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub mod algo;
 pub mod generate;
 #[cfg(feature = "graphmap")]
 pub mod graphmap;
+#[cfg(feature = "dense_graph")]
+pub mod dense_graph;
 #[path = "graph.rs"]
 mod graph_impl;
 pub mod dot;
@@ -46,6 +48,7 @@ pub mod csr;
 mod iter_format;
 mod isomorphism;
 mod traits_graph;
+mod dense_mapping;
 mod util;
 #[cfg(feature = "quickcheck")]
 mod quickcheck;

--- a/tests/dense_graph.rs
+++ b/tests/dense_graph.rs
@@ -1,0 +1,137 @@
+#![cfg(feature = "dense_graph")]
+
+extern crate petgraph;
+
+use petgraph::dense_graph::*;
+
+#[test]
+fn test_new() {
+    DenseGraph::<i32, i32>::new();
+}
+
+#[test]
+fn test_default() {
+    DenseGraph::<i32, i32>::default();
+}
+
+#[test]
+fn test_with_capacity() {
+    DenseGraph::<i32, i32>::with_capacity(10, 5);
+}
+
+#[test]
+fn test_add_node() {
+    let mut g: DenseGraph<char, ()> = DenseGraph::new();
+    g.add_node('a');
+    g.add_node('b');
+}
+
+#[test]
+fn test_remove_node() {
+    let mut g: DenseGraph<char, ()> = DenseGraph::new();
+    let a = g.add_node('a');
+    g.remove_node(a);
+}
+
+#[test]
+fn test_add_edge() {
+    let mut g: DenseGraph<char, ()> = DenseGraph::new();
+    let a = g.add_node('a');
+    let b = g.add_node('b');
+    let c = g.add_node('c');
+    g.add_edge(a, b, ());
+    g.add_edge(b, c, ());
+}
+
+#[test]
+fn test_add_edge_with_weights() {
+    let mut g: DenseGraph<char, bool> = DenseGraph::new();
+    let a = g.add_node('a');
+    let b = g.add_node('b');
+    let c = g.add_node('c');
+    g.add_edge(a, b, true);
+    g.add_edge(b, c, false);
+}
+
+#[test]
+fn test_node_indexing() {
+    let mut g: DenseGraph<char, ()> = DenseGraph::new();
+    let a = g.add_node('a');
+    let b = g.add_node('b');
+    assert_eq!(g[a], 'a');
+    assert_eq!(g[b], 'b');
+}
+
+#[test]
+fn test_edge_indexing() {
+    let mut g: DenseGraph<char, bool> = DenseGraph::new();
+    let a = g.add_node('a');
+    let b = g.add_node('b');
+    let c = g.add_node('c');
+    let ab = g.add_edge(a, b, true);
+    let bc = g.add_edge(b, c, false);
+    assert_eq!(g[ab], true);
+    assert_eq!(g[bc], false);
+}
+
+#[test]
+fn test_neighbors() {
+    let mut g: DenseGraph<char, ()> = DenseGraph::new();
+    let a = g.add_node('a');
+    let b = g.add_node('b');
+    let c = g.add_node('c');
+    let _ = g.add_edge(a, b, ());
+    let _ = g.add_edge(a, c, ());
+
+    let a_neighbors: Vec<_> = g.neighbors(a).collect();
+    assert_eq!(a_neighbors, vec![b, c]);
+
+    let b_neighbors: Vec<_> = g.neighbors(b).collect();
+    assert_eq!(b_neighbors, vec![]);
+
+    let c_neighbors: Vec<_> = g.neighbors(c).collect();
+    assert_eq!(c_neighbors, vec![]);
+}
+
+#[test]
+fn test_neighbors_undirected() {
+    let mut g: DenseUnGraph<char, ()> = DenseGraph::new_undirected();
+    let a = g.add_node('a');
+    let b = g.add_node('b');
+    let c = g.add_node('c');
+    let _ = g.add_edge(a, b, ());
+    let _ = g.add_edge(a, c, ());
+
+    let a_neighbors: Vec<_> = g.neighbors(a).collect();
+    assert_eq!(a_neighbors, vec![b, c]);
+
+    let b_neighbors: Vec<_> = g.neighbors(b).collect();
+    assert_eq!(b_neighbors, vec![a]);
+
+    let c_neighbors: Vec<_> = g.neighbors(c).collect();
+    assert_eq!(c_neighbors, vec![a]);
+}
+
+#[test]
+fn test_from_edges() {
+    let _: DenseGraph<char, bool> = DenseGraph::from_edges(&[
+        (0, 5), (0, 2), (0, 3), (0, 1),
+        (1, 3),
+        (2, 3), (2, 4),
+        (4, 0), (4, 5),
+    ]);
+}
+
+#[test]
+fn test_edges() {
+    let g: DenseGraph<char, bool> = DenseGraph::from_edges(&[
+        (0, 5), (0, 2), (0, 3), (0, 1),
+        (1, 3),
+        (2, 3), (2, 4),
+        (4, 0), (4, 5),
+    ]);
+
+    use std::collections::HashSet;
+    let edges: HashSet<EdgeIndex<DefaultIx>> = g.edges(node_index(0)).collect();
+    assert_eq!(edges.len(), 4);
+}


### PR DESCRIPTION
This version adds a `DenseGraph` struct, which implements the basic
graph functionality. The underlying structure is two weight maps and an
adjacency matrix.

The following traits are currently implemented:
- Default
- Index/IndexMut
- Clone

As well as basic node/edge addition.

The DenseMapping/IdGenerator structs allow fast indexing of weights,
combined with automatic index generation. This comes at the cost of
manual and regular resizing of a slice (`std::vec::Vec`). This slice can
probably be replaced with a `std::collections::HashMap` (since it uses
open-addressing under the hood), [stash](https://github.com/Stebalien/stash-rs) or even [vec_map](https://github.com/contain-rs/vec-map).

I was largely inspired from [src/graph.rs](https://github.com/bluss/petgraph/blob/master/src/graph.rs) for most of the implementation, so there's probably a bunch of documentation errors to fix.

__Important note:__ I'm aware there's still a bunch of work to be done and I'll probably need some pointers (#28) concerning the methodology for implementing neighbor iterators/visiting.