### PR TITLE
Fix compilation issue in tests on nightly

### DIFF
--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1491,8 +1491,8 @@ fn filtered_post_order() {
     let mut po = Vec::new();
     let mut dfs = DfsPostOrder::new(&gr, n(0));
     let f = NodeFiltered(&gr, map);
-    while let Some(n) = dfs.next(&f) {
-        po.push(n);
+    while let Some(node) = dfs.next(&f) {
+        po.push(node);
     }
     assert!(!po.contains(&n(1)));
 }


### PR DESCRIPTION
I noticed that a recent update to the nightly toolchain on Travis broke the compilation of `tests/graph.rs`. The issue is simply a naming clash because `node_index` was aliased to `n`, which was also used as a variable in one of the test bodies.