### PR TITLE
Add opt-in serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rand = "0.3"
 odds = { version = "0.2.19" }
 itertools = { version = "0.5" }
 defmac = "0.1"
+serde_json = "*"
 
 [features]
 default = ["graphmap", "stable_graph"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ debug = true
 fixedbitset = { version = "0.1.4" }
 quickcheck = { optional = true, version = "0.4", default-features = false }
 ordermap = { version = "0.2.2", optional = true }
+serde = { version = "0.9.13", optional = true }
+serde_derive = { version = "0.9.13", optional = true }
 
 [dev-dependencies]
 rand = "0.3"
@@ -40,6 +42,7 @@ defmac = "0.1"
 default = ["graphmap", "stable_graph"]
 graphmap = ["ordermap"]
 stable_graph = []
+petgraph_serde = ["serde", "serde_derive"]
 
 # For unstable features
 generate = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,21 +29,19 @@ debug = true
 fixedbitset = { version = "0.1.4" }
 quickcheck = { optional = true, version = "0.4", default-features = false }
 ordermap = { version = "0.2.2", optional = true }
-serde = { version = "0.9.13", optional = true }
-serde_derive = { version = "0.9.13", optional = true }
+serde = { version = "0.9.13", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.3"
 odds = { version = "0.2.19" }
 itertools = { version = "0.5" }
 defmac = "0.1"
-serde_json = "*"
+serde_json = "0.9.10"
 
 [features]
 default = ["graphmap", "stable_graph"]
 graphmap = ["ordermap"]
 stable_graph = []
-petgraph_serde = ["serde", "serde_derive"]
 
 # For unstable features
 generate = []

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -321,6 +321,7 @@ impl<E, Ix: IndexType> Edge<E, Ix>
 /// of removing elements. Indices don't allow as much compile time checking as
 /// references.
 ///
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Graph<N, E, Ty = Directed, Ix = DefaultIx> {
     nodes: Vec<Node<N, Ix>>,
     edges: Vec<Edge<E, Ix>>,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -85,7 +85,7 @@ unsafe impl IndexType for u8 {
 
 /// Node identifier.
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NodeIndex<Ix=DefaultIx>(Ix);
 
 impl<Ix: IndexType> NodeIndex<Ix>
@@ -131,7 +131,7 @@ pub fn edge_index<Ix: IndexType>(index: usize) -> EdgeIndex<Ix> { EdgeIndex::new
 
 /// Edge identifier.
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EdgeIndex<Ix=DefaultIx>(Ix);
 
 impl<Ix: IndexType> EdgeIndex<Ix>
@@ -185,7 +185,7 @@ const DIRECTIONS: [Direction; 2] = [Outgoing, Incoming];
 
 /// The graph's node type.
 #[derive(Debug)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Node<N, Ix = DefaultIx> {
     /// Associated node data.
     pub weight: N,
@@ -213,7 +213,7 @@ impl<N, Ix: IndexType> Node<N, Ix>
 
 /// The graph's edge type.
 #[derive(Debug)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Edge<E, Ix = DefaultIx> {
     /// Associated edge data.
     pub weight: E,
@@ -325,7 +325,7 @@ impl<E, Ix: IndexType> Edge<E, Ix>
 /// of removing elements. Indices don't allow as much compile time checking as
 /// references.
 ///
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Graph<N, E, Ty = Directed, Ix = DefaultIx> {
     nodes: Vec<Node<N, Ix>>,
     edges: Vec<Edge<E, Ix>>,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -85,6 +85,7 @@ unsafe impl IndexType for u8 {
 
 /// Node identifier.
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct NodeIndex<Ix=DefaultIx>(Ix);
 
 impl<Ix: IndexType> NodeIndex<Ix>
@@ -130,6 +131,7 @@ pub fn edge_index<Ix: IndexType>(index: usize) -> EdgeIndex<Ix> { EdgeIndex::new
 
 /// Edge identifier.
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct EdgeIndex<Ix=DefaultIx>(Ix);
 
 impl<Ix: IndexType> EdgeIndex<Ix>
@@ -183,6 +185,7 @@ const DIRECTIONS: [Direction; 2] = [Outgoing, Incoming];
 
 /// The graph's node type.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Node<N, Ix = DefaultIx> {
     /// Associated node data.
     pub weight: N,
@@ -210,6 +213,7 @@ impl<N, Ix: IndexType> Node<N, Ix>
 
 /// The graph's edge type.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Edge<E, Ix = DefaultIx> {
     /// Associated edge data.
     pub weight: E,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,12 @@ extern crate fixedbitset;
 #[cfg(feature = "graphmap")]
 extern crate ordermap;
 
+#[cfg(feature = "petgraph_serde")]
+extern crate serde;
+#[cfg(feature = "petgraph_serde")]
+#[macro_use]
+extern crate serde_derive;
+
 #[doc(no_inline)]
 pub use graph::Graph;
 
@@ -128,11 +134,13 @@ pub use Direction as EdgeDirection;
 
 /// Marker type for a directed graph.
 #[derive(Copy, Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum Directed { }
 copyclone!(Directed);
 
 /// Marker type for an undirected graph.
 #[derive(Copy, Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum Undirected { }
 copyclone!(Undirected);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,9 @@ extern crate fixedbitset;
 #[cfg(feature = "graphmap")]
 extern crate ordermap;
 
-#[cfg(feature = "petgraph_serde")]
-extern crate serde;
-#[cfg(feature = "petgraph_serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 #[doc(no_inline)]
 pub use graph::Graph;
@@ -134,13 +132,13 @@ pub use Direction as EdgeDirection;
 
 /// Marker type for a directed graph.
 #[derive(Copy, Debug)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Directed { }
 copyclone!(Directed);
 
 /// Marker type for an undirected graph.
 #[derive(Copy, Debug)]
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Undirected { }
 copyclone!(Undirected);
 

--- a/src/stable_graph.rs
+++ b/src/stable_graph.rs
@@ -91,7 +91,7 @@ pub use graph::{
 ///
 /// Depends on crate feature `stable_graph` (default). *This is a new feature in
 /// petgraph.  You can contribute to help it achieve parity with Graph.*
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct StableGraph<N, E, Ty = Directed, Ix = DefaultIx>
 {
     g: Graph<Option<N>, Option<E>, Ty, Ix>,

--- a/src/stable_graph.rs
+++ b/src/stable_graph.rs
@@ -91,6 +91,7 @@ pub use graph::{
 ///
 /// Depends on crate feature `stable_graph` (default). *This is a new feature in
 /// petgraph.  You can contribute to help it achieve parity with Graph.*
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct StableGraph<N, E, Ty = Directed, Ix = DefaultIx>
 {
     g: Graph<Option<N>, Option<E>, Ty, Ix>,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,4 +1,5 @@
 extern crate petgraph;
+extern crate serde_json;
 
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -87,6 +88,23 @@ fn undirected()
     assert!(og.find_edge(b, c).is_some());
     assert_graph_consistent(&og);
 
+}
+
+#[test]
+fn serde() {
+    let mut og = Graph::new_undirected();
+    let a = og.add_node(0);
+    let b = og.add_node(1);
+    let c = og.add_node(2);
+    let d = og.add_node(3);
+    let _ = og.add_edge(a, b, 0);
+    let _ = og.add_edge(a, c, 1);
+    og.add_edge(c, a, 2);
+    og.add_edge(a, a, 3);
+    og.add_edge(b, c, 4);
+    og.add_edge(b, a, 5);
+    og.add_edge(a, d, 6);
+    let ser = serde_json::to_string(&og);
 }
 
 #[test]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -104,7 +104,11 @@ fn serde() {
     og.add_edge(b, c, 4);
     og.add_edge(b, a, 5);
     og.add_edge(a, d, 6);
-    let ser = serde_json::to_string(&og);
+    // smoke test round-trip through serialization
+    // would be ideal to assert that the two are equal 
+    let ser = serde_json::to_string(&og).unwrap();
+    println!("Serialized test graph:\n{}", ser);
+    let de: Graph<i64, i64> = serde_json::from_str(&ser).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Adds opt-in serde support for Graph and StableGraph, using serde's best practice for feature naming.  GraphMap support depends on OrderMap adding support for serde, so I've left that derive out for now.

I wrote one unit test to exercise this for Graph but it isn't making any meaningful assertions because Graph doesn't provide any simple way to compare two graphs (and really we'd want to be comparing the exact details of their internals anyway).  It could just as well be removed, since all we're doing is deriving traits and any bugs that we catch would almost certainly be Serde bugs.