### PR TITLE
Add A* pathfinding algorithm

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -44,6 +44,7 @@ pub use super::isomorphism::{
     is_isomorphic_matching,
 };
 pub use super::dijkstra::dijkstra;
+pub use super::astar::astar;
 
 /// [Generic] Return the number of connected components of the graph.
 ///

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -22,16 +22,20 @@ use algo::Measure;
 
 /// [Generic] A* shortest path algorithm.
 ///
-/// Compute the length of the shortest path from `start` to `finish`.
+/// Computes the shortest path from `start` to `finish`, including the total path cost.
 ///
 /// `finish` is implicitly given via the `is_goal` callback, which should return `true` if the
 /// given node is the finish node.
 ///
-/// The function `edge_cost` should return the cost for a particular edge, which is used to compute
-/// path costs.
+/// The function `edge_cost` should return the cost for a particular edge. Edge costs must be
+/// non-negative.
 ///
 /// The function `estimate_cost` should return the estimated cost to the finish for a particular
-/// node, also used to compute path costs.
+/// node. For the algorithm to find the actual shortest path, it should be admissible, meaning that
+/// it should never overestimate the actual cost to get to the nearest goal node. Estimate costs
+/// must also be non-negative.
+///
+/// The graph should be `Visitable` and implement `IntoEdges`.
 ///
 /// ```
 /// use petgraph::Graph;
@@ -57,8 +61,6 @@ use algo::Measure;
 /// let path = astar(&g, a, |finish| finish == f, |e| *e.weight(), |_| 0);
 /// assert_eq!(path, Some((6, vec![a, d, e, f])));
 /// ```
-///
-/// The graph should be `Visitable` and implement `IntoEdges`. Edge costs must be non-negative.
 ///
 /// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
 /// found.

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -55,15 +55,16 @@ use algo::Measure;
 /// ]);
 ///
 /// let path = astar(&g, a, |finish| finish == f, |e| *e.weight(), |_| 0);
-/// assert_eq!(path, Some(vec![a, d, e, f]));
+/// assert_eq!(path, Some((6, vec![a, d, e, f])));
 /// ```
 ///
 /// The graph should be `Visitable` and implement `IntoEdges`. Edge costs must be non-negative.
 ///
-/// Returns a Path of subsequent `NodeId` from start to finish, if one was found.
+/// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
+/// found.
 pub fn astar<G, F, H, K, IsGoal>(graph: G, start: G::NodeId, mut is_goal: IsGoal,
                                      mut edge_cost: F, mut estimate_cost: H)
-    -> Option<Vec<G::NodeId>>
+    -> Option<(K, Vec<G::NodeId>)>
     where G: IntoEdges + Visitable,
           IsGoal: FnMut(G::NodeId) -> bool,
           G::NodeId: Eq + Hash,
@@ -82,7 +83,9 @@ pub fn astar<G, F, H, K, IsGoal>(graph: G, start: G::NodeId, mut is_goal: IsGoal
 
     while let Some(MinScored(_, node)) = visit_next.pop() {
         if is_goal(node) {
-            return Some(path_tracker.reconstruct_path_to(node));
+            let path = path_tracker.reconstruct_path_to(node);
+            let cost = scores[&node];
+            return Some((cost, path));
         }
 
         // Don't visit the same node several times, as the first time it was visited it was using

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -1,0 +1,86 @@
+use std::collections::{
+    HashMap,
+    BinaryHeap,
+};
+use std::collections::hash_map::Entry::{
+    Occupied,
+    Vacant,
+};
+
+use std::hash::Hash;
+
+use scored::MinScored;
+use super::visit::{
+    Visitable,
+    VisitMap,
+    IntoEdges,
+    EdgeRef,
+};
+
+use algo::Measure;
+
+/// [Generic] A* shortest path algorithm.
+///
+/// Compute the length of the shortest path from `start` to the goal node.
+///
+/// The graph should be `Visitable` and implement `IntoEdges`. The function `edge_cost` should
+/// return the cost for a particular edge, which is used to compute path costs.  The function
+/// `estimate_cost` should return the estimated cost to the goal for a particular node, also used
+/// to compute path costs. Edge costs must be non-negative.
+///
+/// Returns a `HashMap` that maps `NodeId` to path cost.
+pub fn astar<G, F, H, K>(graph: G, start: G::NodeId, goal: Option<G::NodeId>,
+                         mut edge_cost: F, mut estimate_cost: H)
+    -> HashMap<G::NodeId, K>
+    where G: IntoEdges + Visitable,
+          G::NodeId: Eq + Hash,
+          F: FnMut(G::EdgeRef) -> K,
+          H: FnMut(G::NodeId) -> K,
+          K: Measure + Copy,
+{
+    let mut visited = graph.visit_map();
+    let mut visit_next = BinaryHeap::new();
+    let mut scores = HashMap::new();
+
+    let zero_score = K::default();
+    scores.insert(start, zero_score);
+    visit_next.push(MinScored(estimate_cost(start), start));
+
+    while let Some(MinScored(_, node)) = visit_next.pop() {
+        if visited.is_visited(&node) {
+            continue
+        }
+
+        if goal.as_ref() == Some(&node) {
+            break
+        }
+
+        for edge in graph.edges(node) {
+            let next = edge.target();
+            if visited.is_visited(&next) {
+                continue
+            }
+
+            let node_score = *scores.get(&node).unwrap();
+            let mut next_score = node_score + edge_cost(edge);
+
+            // TODO: understand this section
+            match scores.entry(next) {
+                Occupied(ent) => if next_score < *ent.get() {
+                    *ent.into_mut() = next_score;
+                } else {
+                    next_score = *ent.get();
+                },
+                Vacant(ent) => {
+                    ent.insert(next_score);
+                }
+            }
+
+            let next_estimate_score = next_score + estimate_cost(next);
+            visit_next.push(MinScored(next_estimate_score, next));
+        }
+        visited.visit(node);
+    }
+
+    scores
+}

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -93,7 +93,7 @@ pub fn astar<G, F, H, K, IsGoal>(graph: G, start: G::NodeId, mut is_goal: IsGoal
 
         // This lookup can be unwrapped without fear of panic since the node was necessarily scored
         // before adding him to `visit_next`.
-        let node_score = *scores.get(&node).unwrap();
+        let node_score = scores[&node];
 
         for edge in graph.edges(node) {
             let next = edge.target();

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -24,16 +24,46 @@ use algo::Measure;
 ///
 /// Compute the length of the shortest path from `start` to `finish`.
 ///
-/// The graph should be `Visitable` and implement `IntoEdges`. The function `edge_cost` should
-/// return the cost for a particular edge, which is used to compute path costs. The function
-/// `estimate_cost` should return the estimated cost to the finish for a particular node, also used
-/// to compute path costs. Edge costs must be non-negative.
+/// `finish` is implicitly given via the `is_goal` callback, which should return `true` if the
+/// given node is the finish node.
+///
+/// The function `edge_cost` should return the cost for a particular edge, which is used to compute
+/// path costs.
+///
+/// The function `estimate_cost` should return the estimated cost to the finish for a particular
+/// node, also used to compute path costs.
+///
+/// ```
+/// use petgraph::Graph;
+/// use petgraph::algo::astar;
+///
+/// let mut g = Graph::new();
+/// let a = g.add_node((0., 0.));
+/// let b = g.add_node((2., 0.));
+/// let c = g.add_node((1., 1.));
+/// let d = g.add_node((0., 2.));
+/// let e = g.add_node((3., 3.));
+/// let f = g.add_node((4., 2.));
+/// let ab = g.add_edge(a, b, 2);
+/// let ad = g.add_edge(a, d, 4);
+/// let bc = g.add_edge(b, c, 1);
+/// let bf = g.add_edge(b, f, 7);
+/// let ce = g.add_edge(c, e, 5);
+/// let ef = g.add_edge(e, f, 1);
+/// let de = g.add_edge(d, e, 1);
+///
+/// let path = astar(&g, a, |finish| finish == f, |e| *e.weight(), |_| 0);
+/// assert_eq!(path, Some(vec![a, d, e, f]));
+/// ```
+///
+/// The graph should be `Visitable` and implement `IntoEdges`. Edge costs must be non-negative.
 ///
 /// Returns a Path of subsequent `NodeId` from start to finish, if one was found.
-pub fn astar<G, F, H, K>(graph: G, start: G::NodeId, finish: G::NodeId,
-                         mut edge_cost: F, mut estimate_cost: H)
+pub fn astar<G, F, H, K, IsGoal>(graph: G, start: G::NodeId, is_goal: IsGoal,
+                                     mut edge_cost: F, mut estimate_cost: H)
     -> Option<Path<G>>
     where G: IntoEdges + Visitable,
+          IsGoal: Fn(G::NodeId) -> bool,
           G::NodeId: Eq + Hash,
           F: FnMut(G::EdgeRef) -> K,
           H: FnMut(G::NodeId) -> K,
@@ -49,8 +79,8 @@ pub fn astar<G, F, H, K>(graph: G, start: G::NodeId, finish: G::NodeId,
     visit_next.push(MinScored(estimate_cost(start), start));
 
     while let Some(MinScored(_, node)) = visit_next.pop() {
-        if node == finish {
-            return Some(path_tracker.reconstruct_path_to(finish));
+        if is_goal(node) {
+            return Some(path_tracker.reconstruct_path_to(node));
         }
 
         // Don't visit the same node several times, as the first time it was visited it was using

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -55,11 +55,9 @@ pub fn astar<G, F, H, K>(graph: G, start: G::NodeId, finish: G::NodeId,
 
         // Don't visit the same node several times, as the first time it was visited it was using
         // the shortest available path.
-        if visited.is_visited(&node) {
+        if !visited.visit(node) {
             continue
         }
-
-        visited.visit(node);
 
         // This lookup can be unwrapped without fear of panic since the node was necessarily scored
         // before adding him to `visit_next`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ mod graph_impl;
 pub mod dot;
 pub mod unionfind;
 mod dijkstra;
+mod astar;
 pub mod csr;
 mod iter_format;
 mod isomorphism;

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -35,6 +35,7 @@ use petgraph::visit::{
 use petgraph::algo::{
     DfsSpace,
     dijkstra,
+    astar,
 };
 
 use petgraph::dot::{
@@ -340,6 +341,32 @@ fn dijk() {
 
     let scores = dijkstra(&g, a, Some(c), |e| *e.weight());
     assert_eq!(scores[&c], 9);
+}
+
+#[test]
+fn astar_test() {
+    let mut g = Graph::new();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    let c = g.add_node("C");
+    let d = g.add_node("D");
+    let e = g.add_node("E");
+    let f = g.add_node("F");
+    g.add_edge(a, b, 7);
+    g.add_edge(c, a, 9);
+    g.add_edge(a, d, 14);
+    g.add_edge(b, c, 10);
+    g.add_edge(d, c, 2);
+    g.add_edge(d, e, 9);
+    g.add_edge(b, f, 15);
+    g.add_edge(c, f, 11);
+    g.add_edge(e, f, 6);
+
+    let path = astar(&g, a, e, |e| *e.weight(), |_| 0);
+    assert_eq!(path, Some(vec![a, d, e]));
+
+    let path = astar(&g, e, b, |e| *e.weight(), |_| 0);
+    assert_eq!(path, None);
 }
 
 #[cfg(feature = "generate")]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -344,7 +344,7 @@ fn dijk() {
 }
 
 #[test]
-fn astar_test() {
+fn test_astar_null_heuristic() {
     let mut g = Graph::new();
     let a = g.add_node("A");
     let b = g.add_node("B");
@@ -367,6 +367,38 @@ fn astar_test() {
 
     let path = astar(&g, e, |finish| finish == b, |e| *e.weight(), |_| 0);
     assert_eq!(path, None);
+}
+
+#[test]
+fn test_astar_manhattan_heuristic() {
+    let mut g = Graph::new();
+    let a = g.add_node((0., 0.));
+    let b = g.add_node((2., 0.));
+    let c = g.add_node((1., 1.));
+    let d = g.add_node((0., 2.));
+    let e = g.add_node((3., 3.));
+    let f = g.add_node((4., 2.));
+    g.add_edge(a, b, 2.);
+    g.add_edge(a, d, 4.);
+    g.add_edge(b, c, 1.);
+    g.add_edge(b, f, 7.);
+    g.add_edge(c, e, 5.);
+    g.add_edge(e, f, 1.);
+    g.add_edge(d, e, 1.);
+
+    let path = astar(&g, a, |finish| finish == f, |e| *e.weight(),
+    |node| {
+        let (x1, y1): (f32, f32) = g[node];
+        let (x2, y2): (f32, f32) = g[f];
+
+        let (x, y) = (x2 + x1, y2 + y1);
+
+        x.powi(2) + y.powi(2)
+    });
+
+    // TODO: check this on paper
+    assert_eq!(path, Some(vec![a, d, e, f]));
+    // assert_eq!(path, Some(vec![a, b, f]));
 }
 
 #[cfg(feature = "generate")]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -365,6 +365,10 @@ fn test_astar_null_heuristic() {
     let path = astar(&g, a, |finish| finish == e, |e| *e.weight(), |_| 0);
     assert_eq!(path, Some((23, vec![a, d, e])));
 
+    // check against dijkstra
+    let dijkstra_run = dijkstra(&g, a, Some(e), |e| *e.weight());
+    assert_eq!(dijkstra_run[&e], 23);
+
     let path = astar(&g, e, |finish| finish == b, |e| *e.weight(), |_| 0);
     assert_eq!(path, None);
 }
@@ -395,6 +399,10 @@ fn test_astar_manhattan_heuristic() {
     });
 
     assert_eq!(path, Some((6., vec![a, d, e, f])));
+
+    // check against dijkstra
+    let dijkstra_run = dijkstra(&g, a, Some(f), |e| *e.weight());
+    assert_eq!(dijkstra_run[&f], 6.);
 }
 
 #[cfg(feature = "generate")]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -362,10 +362,10 @@ fn astar_test() {
     g.add_edge(c, f, 11);
     g.add_edge(e, f, 6);
 
-    let path = astar(&g, a, e, |e| *e.weight(), |_| 0);
+    let path = astar(&g, a, |finish| finish == e, |e| *e.weight(), |_| 0);
     assert_eq!(path, Some(vec![a, d, e]));
 
-    let path = astar(&g, e, b, |e| *e.weight(), |_| 0);
+    let path = astar(&g, e, |finish| finish == b, |e| *e.weight(), |_| 0);
     assert_eq!(path, None);
 }
 

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -363,7 +363,7 @@ fn test_astar_null_heuristic() {
     g.add_edge(e, f, 6);
 
     let path = astar(&g, a, |finish| finish == e, |e| *e.weight(), |_| 0);
-    assert_eq!(path, Some(vec![a, d, e]));
+    assert_eq!(path, Some((23, vec![a, d, e])));
 
     let path = astar(&g, e, |finish| finish == b, |e| *e.weight(), |_| 0);
     assert_eq!(path, None);
@@ -396,9 +396,7 @@ fn test_astar_manhattan_heuristic() {
         x.powi(2) + y.powi(2)
     });
 
-    // TODO: check this on paper
-    assert_eq!(path, Some(vec![a, d, e, f]));
-    // assert_eq!(path, Some(vec![a, b, f]));
+    assert_eq!(path, Some((6., vec![a, d, e, f])));
 }
 
 #[cfg(feature = "generate")]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -391,9 +391,7 @@ fn test_astar_manhattan_heuristic() {
         let (x1, y1): (f32, f32) = g[node];
         let (x2, y2): (f32, f32) = g[f];
 
-        let (x, y) = (x2 + x1, y2 + y1);
-
-        x.powi(2) + y.powi(2)
+        (x2 - x1).abs() + (y2 - y1).abs()
     });
 
     assert_eq!(path, Some((6., vec![a, d, e, f])));


### PR DESCRIPTION
## Summary

I've written the current A* to return the full path from start to finish, unlike the Dijkstra that simply computes all costs, stopping if the goal is found. Additionally, I could add in the computed cost of the path.

I've added a test that validates a basic usage, although there should be a proof that the heuristic drives the pathfinding.

Performance-wise, the tracking of previous nodes to later rebuild the path from start to finish adds on the Dijkstra's performance cost, otherwise it's roughly equivalent.

## Sidenotes

Some work could be done to allow more flexibility in terms of data-structures used by the algorithm, as it currently requires that node IDs be `Eq` + `Hash` when we could have another version only requiring `Ord` which would use trees instead of hashmaps.

## Questions

- [x] Should the path returned be the list of node IDs or the actual edge IDs?
- [x] Should the pathfinding algorithms be reworked to share some common "flexible" interface?
- [ ] Should there be bench tests on the A* vs the Dijkstra when `H(x) = 0` to measure the cost of tracking the path?

(fixes #138)