### PR TITLE
Modify bellman_ford to work with undirected graphs, and add quickcheck test

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -33,7 +33,7 @@ use super::unionfind::UnionFind;
 use super::graph::{
     IndexType,
 };
-use visit::{Data, NodeRef, IntoNodeReferences};
+use visit::{Data, NodeRef, IntoNodeReferences, GraphProp};
 use data::{
     Element,
 };
@@ -551,7 +551,7 @@ pub struct NegativeCycle(());
 /// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
 pub fn bellman_ford<G>(g: G, source: G::NodeId)
     -> Result<(Vec<G::EdgeWeight>, Vec<Option<G::NodeId>>), NegativeCycle>
-    where G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    where G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable + GraphProp,
           G::EdgeWeight: FloatMeasure,
 {
     let mut predecessor = vec![None; g.node_bound()];
@@ -570,6 +570,11 @@ pub fn bellman_ford<G>(g: G, source: G::NodeId)
             if distance[ix(i)] + w < distance[ix(j)] {
                 distance[ix(j)] = distance[ix(i)] + w;
                 predecessor[ix(j)] = Some(i);
+                did_update = true;
+            }
+            if !g.is_directed() && distance[ix(j)] + w < distance[ix(i)] {
+                distance[ix(i)] = distance[ix(j)] + w;
+                predecessor[ix(i)] = Some(j);
                 did_update = true;
             }
         }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -556,6 +556,7 @@ pub fn bellman_ford<G>(g: G, source: G::NodeId)
 {
     let mut predecessor = vec![None; g.node_bound()];
     let mut distance = vec![<_>::infinite(); g.node_bound()];
+    let is_undirected = !g.is_directed();
 
     let ix = |i| g.to_index(i);
 
@@ -572,7 +573,7 @@ pub fn bellman_ford<G>(g: G, source: G::NodeId)
                 predecessor[ix(j)] = Some(i);
                 did_update = true;
             }
-            if !g.is_directed() && distance[ix(j)] + w < distance[ix(i)] {
+            if is_undirected && distance[ix(j)] + w < distance[ix(i)] {
                 distance[ix(i)] = distance[ix(j)] + w;
                 predecessor[ix(i)] = Some(j);
                 did_update = true;

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -737,3 +737,20 @@ quickcheck! {
         true
     }
 }
+
+quickcheck! {
+    fn test_bellman_ford_undir(gr: Graph<(), f32, Undirected>) -> bool {
+        let mut gr = gr;
+        for elt in gr.edge_weights_mut() {
+            *elt = elt.abs();
+        }
+        if gr.node_count() == 0 {
+            return true;
+        }
+        for (i, start) in gr.node_indices().enumerate() {
+            if i >= 10 { break; } // testing all is too slow
+            bellman_ford(&gr, start).unwrap();
+        }
+        true
+    }
+}


### PR DESCRIPTION
Fixes #150:
 * Adds a check in bellman_ford that applies edges in both directions if the graph is undirected.
 * Adds a quickcheck test to verify that bellman_ford returns results for undirected graphs with non-negative edge weights.