### PR TITLE
Fix compilation for rust nightly for 0.2.*

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -418,7 +418,7 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
         let node = Node{weight: weight, next: [EdgeIndex::end(), EdgeIndex::end()]};
         let node_idx = NodeIndex::new(self.nodes.len());
         // check for max capacity, except if we use usize
-        assert!(Ix::max().index() == !0 || NodeIndex::end() != node_idx);
+        assert!(<Ix as IndexType>::max().index() == !0 || NodeIndex::end() != node_idx);
         self.nodes.push(node);
         node_idx
     }
@@ -455,7 +455,7 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix>
     {
         let edge_idx = EdgeIndex::new(self.edges.len());
-        assert!(Ix::max().index() == !0 || EdgeIndex::end() != edge_idx);
+        assert!(<Ix as IndexType>::max().index() == !0 || EdgeIndex::end() != edge_idx);
         let mut edge = Edge {
             weight: weight,
             node: [a, b],


### PR DESCRIPTION
Same patch as #154, but applied to `branch-0.2` branch. I'm not sure there's a branch for `0.3` versions, but this same commit could be applied to a 0.3 version as well.

---

Very small change to remove ambiguity between Ord::max and IndexType::max in two locations.

Fixes #153.