### PR TITLE
Stable graph bugfixes: neighbors, edges, find_edge

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -868,18 +868,22 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
         } else {
             match self.nodes.get(a.index()) {
                 None => None,
-                Some(node) => {
-                    let mut edix = node.next[0];
-                    while let Some(edge) = self.edges.get(edix.index()) {
-                        if edge.node[1] == b {
-                            return Some(edix)
-                        }
-                        edix = edge.next[0];
-                    }
-                    None
-                }
+                Some(node) => self.find_edge_directed_from_node(node, b)
             }
         }
+    }
+
+    fn find_edge_directed_from_node(&self, node: &Node<N, Ix>, b: NodeIndex<Ix>)
+        -> Option<EdgeIndex<Ix>>
+    {
+        let mut edix = node.next[0];
+        while let Some(edge) = self.edges.get(edix.index()) {
+            if edge.node[1] == b {
+                return Some(edix)
+            }
+            edix = edge.next[0];
+        }
+        None
     }
 
     /// Lookup an edge between `a` and `b`, in either direction.
@@ -893,20 +897,24 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
     {
         match self.nodes.get(a.index()) {
             None => None,
-            Some(node) => {
-                for &d in &DIRECTIONS {
-                    let k = d.index();
-                    let mut edix = node.next[k];
-                    while let Some(edge) = self.edges.get(edix.index()) {
-                        if edge.node[1 - k] == b {
-                            return Some((edix, d))
-                        }
-                        edix = edge.next[k];
-                    }
+            Some(node) => self.find_edge_undirected_from_node(node, b),
+        }
+    }
+
+    fn find_edge_undirected_from_node(&self, node: &Node<N, Ix>, b: NodeIndex<Ix>)
+        -> Option<(EdgeIndex<Ix>, Direction)>
+    {
+        for &d in &DIRECTIONS {
+            let k = d.index();
+            let mut edix = node.next[k];
+            while let Some(edge) = self.edges.get(edix.index()) {
+                if edge.node[1 - k] == b {
+                    return Some((edix, d))
                 }
-                None
+                edix = edge.next[k];
             }
         }
+        None
     }
 
     /// Return an iterator over either the nodes without edges to them

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -17,6 +17,7 @@ use graphmap::{
     GraphMap,
     NodeTrait,
 };
+use visit::NodeIndexable;
 
 /// `Arbitrary` for `Graph` creates a graph by selecting a node count
 /// and a probability for each possible edge to exist.
@@ -113,6 +114,16 @@ impl<N, E, Ty, Ix> Arbitrary for StableGraph<N, E, Ty, Ix>
                 let p: f64 = g.gen();
                 if p <= edge_prob {
                     gr.add_edge(i, j, E::arbitrary(g));
+                }
+            }
+        }
+        if bool::arbitrary(g) {
+            // potentially remove nodes to make holes in nodes & edge sets
+            let n = u8::arbitrary(g) % (gr.node_count() as u8);
+            for _ in 0..n {
+                let ni = node_index(usize::arbitrary(g) % gr.node_bound());
+                if gr.node_weight(ni).is_some() {
+                    gr.remove_node(ni);
                 }
             }
         }

--- a/src/stable_graph.rs
+++ b/src/stable_graph.rs
@@ -1160,7 +1160,9 @@ impl<N, E, Ty, Ix> NodeIndexable for StableGraph<N, E, Ty, Ix>
 {
     /// Return an upper bound of the node indices in the graph
     fn node_bound(&self) -> usize {
-        self.g.nodes.iter().rposition(|elt| elt.weight.is_some()).unwrap_or(0) + 1
+        self.node_indices()
+            .next_back()
+            .map_or(0, |i| i.index() + 1)
     }
     fn to_index(&self, ix: NodeIndex<Ix>) -> usize { ix.index() }
     fn from_index(&self, ix: usize) -> Self::NodeId { NodeIndex::new(ix) }

--- a/src/stable_graph.rs
+++ b/src/stable_graph.rs
@@ -284,7 +284,13 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
     }
 
     pub fn contains_node(&self, a: NodeIndex<Ix>) -> bool {
-        self.g.nodes.get(a.index()).map_or(false, |no| no.weight.is_some())
+        self.get_node(a).is_some()
+    }
+
+    // Return the Node if it is not vacant (non-None weight)
+    fn get_node(&self, a: NodeIndex<Ix>) -> Option<&Node<Option<N>, Ix>> {
+        self.g.nodes.get(a.index())
+                    .and_then(|node| node.weight.as_ref().map(move |_| node))
     }
 
     /// Add an edge from `a` to `b` to the graph, with its associated
@@ -513,7 +519,7 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
         Neighbors {
             skip_start: a,
             edges: &self.g.edges,
-            next: match self.g.nodes.get(a.index()) {
+            next: match self.get_node(a) {
                 None => [EdgeIndex::end(), EdgeIndex::end()],
                 Some(n) => n.next,
             }
@@ -562,7 +568,7 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
             skip_start: a,
             edges: &self.g.edges,
             direction: None,
-            next: match self.g.nodes.get(a.index()) {
+            next: match self.get_node(a) {
                 None => [EdgeIndex::end(), EdgeIndex::end()],
                 Some(n) => n.next,
             },

--- a/src/stable_graph.rs
+++ b/src/stable_graph.rs
@@ -451,12 +451,31 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
     /// connected to `a` (and `b`, if the graph edges are undirected).
     pub fn find_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<EdgeIndex<Ix>>
     {
-        let index = self.g.find_edge(a, b);
-        if let Some(i) = index {
-            debug_assert!(self.g.edges[i.index()].weight.is_some());
+        if !self.is_directed() {
+            self.find_edge_undirected(a, b).map(|(ix, _)| ix)
+        } else {
+            match self.get_node(a) {
+                None => None,
+                Some(node) => self.g.find_edge_directed_from_node(node, b)
+            }
         }
-        index
     }
+
+    /// Lookup an edge between `a` and `b`, in either direction.
+    ///
+    /// If the graph is undirected, then this is equivalent to `.find_edge()`.
+    ///
+    /// Return the edge index and its directionality, with `Outgoing` meaning
+    /// from `a` to `b` and `Incoming` the reverse,
+    /// or `None` if the edge does not exist.
+    pub fn find_edge_undirected(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<(EdgeIndex<Ix>, Direction)>
+    {
+        match self.get_node(a) {
+            None => None,
+            Some(node) => self.g.find_edge_undirected_from_node(node, b),
+        }
+    }
+
 
     /// Return an iterator of all nodes with an edge starting from `a`.
     ///

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -28,6 +28,22 @@ fn node_indices() {
     assert_eq!(iter.next(), None);
 }
 
+#[test]
+fn node_bound() {
+    let mut g = StableGraph::<_, ()>::new();
+    assert_eq!(g.node_bound(), g.node_count());
+    for i in 0..10 {
+        g.add_node(i);
+        assert_eq!(g.node_bound(), g.node_count());
+    }
+    let full_count = g.node_count();
+    g.remove_node(n(0));
+    g.remove_node(n(2));
+    assert_eq!(g.node_bound(), full_count);
+    g.clear();
+    assert_eq!(g.node_bound(), 0);
+}
+
 fn assert_sccs_eq(mut res: Vec<Vec<NodeIndex>>, normalized: Vec<Vec<NodeIndex>>) {
     // normalize the result and compare with the answer.
     for scc in &mut res {

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -200,3 +200,46 @@ fn test_edge_iterators_undir() {
             gr.edges(i));
     }
 }
+
+#[test]
+fn iterators_undir() {
+    let mut g = StableUnGraph::<_, _>::default();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    g.extend_with_edges(&[
+        (a, b, 1),
+        (a, c, 2),
+        (b, c, 3),
+        (c, c, 4),
+        (a, d, 5),
+    ]);
+    g.remove_node(b);
+
+    itertools::assert_equal(
+        g.neighbors(a),
+        vec![d, c],
+    );
+    itertools::assert_equal(
+        g.neighbors(c),
+        vec![c, a],
+    );
+    itertools::assert_equal(
+        g.neighbors(d),
+        vec![a],
+    );
+
+    // the node that was removed
+    itertools::assert_equal(
+        g.neighbors(b),
+        vec![],
+    );
+
+    // remove one more
+    g.remove_node(c);
+    itertools::assert_equal(
+        g.neighbors(c),
+        vec![],
+    );
+}


### PR DESCRIPTION
- Fix StableGraph's Arbitrary (for quickcheck) to make stable graphs with holes sometimes
- Fix bugs found as a result(!)
- StableGraph's `neighbors`, `edges` (and similar iterator methods) and `find_edge` all could panic or return wrong information when called with nodes that don't exist. Fix these methods so that they agree with their documentation.
- Random fix to `StableGraph::node_bound` too, it was returning 1 when the graph was empty, should be 0.