### PR TITLE
Add .edge_indices() for StableGraph and some various graph traits

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1840,6 +1840,8 @@ impl<Ix: IndexType> DoubleEndedIterator for NodeIndices<Ix> {
     }
 }
 
+impl<Ix: IndexType> ExactSizeIterator for NodeIndices<Ix> {}
+
 /// Iterator over the edge indices of a graph.
 #[derive(Clone, Debug)]
 pub struct EdgeIndices<Ix = DefaultIx> {
@@ -1864,6 +1866,8 @@ impl<Ix: IndexType> DoubleEndedIterator for EdgeIndices<Ix> {
         self.r.next_back().map(edge_index)
     }
 }
+
+impl<Ix: IndexType> ExactSizeIterator for EdgeIndices<Ix> {}
 
 /// Reference to a `Graph` edge.
 #[derive(Debug)]
@@ -1922,6 +1926,20 @@ impl<'a, N, Ix> Iterator for NodeReferences<'a, N, Ix>
         self.iter.size_hint()
     }
 }
+
+impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
+    where Ix: IndexType
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|(i, node)|
+            (node_index(i), &node.weight)
+        )
+    }
+}
+
+impl<'a, N, Ix> ExactSizeIterator for NodeReferences<'a, N, Ix>
+    where Ix: IndexType
+{ }
 
 impl<'a, Ix, E> EdgeReference<'a, E, Ix>
     where Ix: IndexType,
@@ -1985,6 +2003,10 @@ impl<'a, E, Ix> DoubleEndedIterator for EdgeReferences<'a, E, Ix>
         )
     }
 }
+
+impl<'a, E, Ix> ExactSizeIterator for EdgeReferences<'a, E, Ix>
+    where Ix: IndexType
+{}
 
 #[cfg(feature = "stable_graph")]
 pub mod stable_graph;

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1819,7 +1819,7 @@ impl<Ix: IndexType> WalkNeighbors<Ix> {
 #[derive(Clone, Debug)]
 pub struct NodeIndices<Ix = DefaultIx> {
     r: Range<usize>,
-    ty: PhantomData<Ix>,
+    ty: PhantomData<fn() -> Ix>,
 }
 
 impl<Ix: IndexType> Iterator for NodeIndices<Ix> {
@@ -1844,7 +1844,7 @@ impl<Ix: IndexType> DoubleEndedIterator for NodeIndices<Ix> {
 #[derive(Clone, Debug)]
 pub struct EdgeIndices<Ix = DefaultIx> {
     r: Range<usize>,
-    ty: PhantomData<Ix>,
+    ty: PhantomData<fn() -> Ix>,
 }
 
 impl<Ix: IndexType> Iterator for EdgeIndices<Ix> {

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1362,6 +1362,11 @@ impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
             } else { None }
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, hi) = self.iter.size_hint();
+        (0, hi)
+    }
 }
 
 impl<'a, N, Ix: IndexType> DoubleEndedIterator for NodeIndices<'a, N, Ix> {
@@ -1402,6 +1407,11 @@ impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
                 Some(edge_index(i))
             } else { None }
         })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, hi) = self.iter.size_hint();
+        (0, hi)
     }
 }
 

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -27,6 +27,7 @@ use iter_format::{
     NoPretty,
     DebugMap,
 };
+use iter_utils::IterUtilsExt;
 
 use super::{
     Edge,
@@ -1008,9 +1009,9 @@ impl<'a, N, Ix> Iterator for NodeReferences<'a, N, Ix>
     type Item = (NodeIndex<Ix>, &'a N);
 
     fn next(&mut self) -> Option<Self::Item> {
-        (&mut self.iter).filter_map(|(i, node)| {
+        self.iter.find_map(|(i, node)| {
             node.weight.as_ref().map(move |w| (node_index(i), w))
-        }).next()
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1023,9 +1024,9 @@ impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
     where Ix: IndexType
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        (&mut self.iter).filter_map(|(i, node)| {
+        self.iter.rfind_map(|(i, node)| {
             node.weight.as_ref().map(move |w| (node_index(i), w))
-        }).next_back()
+        })
     }
 }
 
@@ -1191,7 +1192,7 @@ impl<'a, E, Ix> Iterator for EdgeReferences<'a, E, Ix>
     type Item = EdgeReference<'a, E, Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        (&mut self.iter).filter_map(|(i, edge)|
+        self.iter.find_map(|(i, edge)|
             edge.weight.as_ref().map(move |weight| {
                 EdgeReference {
                     index: edge_index(i),
@@ -1199,7 +1200,6 @@ impl<'a, E, Ix> Iterator for EdgeReferences<'a, E, Ix>
                     weight: weight,
                 }
             }))
-            .next()
     }
 }
 
@@ -1207,7 +1207,7 @@ impl<'a, E, Ix> DoubleEndedIterator for EdgeReferences<'a, E, Ix>
     where Ix: IndexType
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        (&mut self.iter).filter_map(|(i, edge)|
+        self.iter.rfind_map(|(i, edge)|
             edge.weight.as_ref().map(move |weight| {
                 EdgeReference {
                     index: edge_index(i),
@@ -1215,7 +1215,6 @@ impl<'a, E, Ix> DoubleEndedIterator for EdgeReferences<'a, E, Ix>
                     weight: weight,
                 }
             }))
-            .next_back()
     }
 }
 
@@ -1357,21 +1356,21 @@ impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
     type Item = NodeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.by_ref().filter_map(|(i, node)| {
+        self.iter.find_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(node_index(i))
             } else { None }
-        }).next()
+        })
     }
 }
 
 impl<'a, N, Ix: IndexType> DoubleEndedIterator for NodeIndices<'a, N, Ix> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.by_ref().filter_map(|(i, node)| {
+        self.iter.rfind_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(node_index(i))
             } else { None }
-        }).next_back()
+        })
     }
 }
 
@@ -1398,21 +1397,21 @@ impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
     type Item = EdgeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.by_ref().filter_map(|(i, node)| {
+        self.iter.find_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(edge_index(i))
             } else { None }
-        }).next()
+        })
     }
 }
 
 impl<'a, E, Ix: IndexType> DoubleEndedIterator for EdgeIndices<'a, E, Ix> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.by_ref().filter_map(|(i, node)| {
+        self.iter.rfind_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(edge_index(i))
             } else { None }
-        }).next_back()
+        })
     }
 }
 

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -482,6 +482,13 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
         }
     }
 
+    /// Return an iterator over the node indices of the graph
+    pub fn edge_indices(&self) -> EdgeIndices<E, Ix> {
+        EdgeIndices {
+            iter: enumerate(self.raw_edges())
+        }
+    }
+
     /// Lookup an edge from `a` to `b`.
     ///
     /// Computes in **O(e')** time, where **e'** is the number of edges
@@ -1380,6 +1387,33 @@ impl<N, E, Ty, Ix> NodeIndexable for StableGraph<N, E, Ty, Ix>
     }
     fn to_index(&self, ix: NodeIndex<Ix>) -> usize { ix.index() }
     fn from_index(&self, ix: usize) -> Self::NodeId { NodeIndex::new(ix) }
+}
+
+/// Iterator over the edge indices of a graph.
+pub struct EdgeIndices<'a, E: 'a, Ix: 'a = DefaultIx> {
+    iter: iter::Enumerate<slice::Iter<'a, Edge<Option<E>, Ix>>>,
+}
+
+impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
+    type Item = EdgeIndex<Ix>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.by_ref().filter_map(|(i, node)| {
+            if node.weight.is_some() {
+                Some(edge_index(i))
+            } else { None }
+        }).next()
+    }
+}
+
+impl<'a, E, Ix: IndexType> DoubleEndedIterator for EdgeIndices<'a, E, Ix> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.by_ref().filter_map(|(i, node)| {
+            if node.weight.is_some() {
+                Some(edge_index(i))
+            } else { None }
+        }).next_back()
+    }
 }
 
 

--- a/src/iter_utils.rs
+++ b/src/iter_utils.rs
@@ -1,0 +1,31 @@
+
+pub trait IterUtilsExt : Iterator {
+    /// Return the first element that maps to `Some(_)`, or None if the iterator
+    /// was exhausted.
+    fn find_map<F, R>(&mut self, mut f: F) -> Option<R>
+        where F: FnMut(Self::Item) -> Option<R>
+    {
+        while let Some(elt) = self.next() {
+            if let result @ Some(_) = f(elt) {
+                return result;
+            }
+        }
+        None
+    }
+
+    /// Return the last element from the back that maps to `Some(_)`, or
+    /// None if the iterator was exhausted.
+    fn rfind_map<F, R>(&mut self, mut f: F) -> Option<R>
+        where F: FnMut(Self::Item) -> Option<R>,
+              Self: DoubleEndedIterator,
+    {
+        while let Some(elt) = self.next_back() {
+            if let result @ Some(_) = f(elt) {
+                return result;
+            }
+        }
+        None
+    }
+}
+
+impl<I> IterUtilsExt for I where I: Iterator { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod dijkstra;
 mod astar;
 pub mod csr;
 mod iter_format;
+mod iter_utils;
 mod isomorphism;
 mod traits_graph;
 mod util;


### PR DESCRIPTION
- Add StableGraph::edge_indices()
- Factor out the helper methods find_map, rfind_map
- Graph:
    - DoubleEndedIterator for NodeReferences
    - ExactSizeIterator for NodeReferences, EdgeReferences, NodeIndices,
      EdgeIndices
