### PR TITLE
Add IntoEdgesDirected trait

### DIFF
--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -10,7 +10,7 @@ use {
 };
 use visit::{Data, IntoNodeIdentifiers, GraphProp, NodeIndexable, IntoNeighborsDirected};
 use visit::{IntoNeighbors, IntoNodeReferences, IntoEdgeReferences, Visitable};
-use visit::{NodeCompactIndexable, GetAdjacencyMatrix, NodeCount, IntoEdges};
+use visit::{NodeCompactIndexable, GetAdjacencyMatrix, NodeCount, IntoEdges, IntoEdgesDirected};
 use data::{DataMap, DataMapMut};
 
 
@@ -67,6 +67,7 @@ DataMapMut!{delegate_impl [['a, G], G, Frozen<'a, G>, access0]}
 GetAdjacencyMatrix!{delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 IntoEdgeReferences!{delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twice]}
 IntoEdges!{delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twice]}
+IntoEdgesDirected!{delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twice]}
 IntoNeighbors!{delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twice]}
 IntoNeighborsDirected!{delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twice]}
 IntoNodeIdentifiers!{delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twice]}

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -22,7 +22,7 @@ use iter_format::{
 };
 
 use visit::EdgeRef;
-use visit::{IntoNodeReferences, IntoEdges};
+use visit::{IntoNodeReferences, IntoEdges, IntoEdgesDirected};
 use util::enumerate;
 
 #[cfg(feature = "serde-1")]
@@ -1507,6 +1507,16 @@ impl<'a, N, E, Ty, Ix> IntoEdges for &'a Graph<N, E, Ty, Ix>
     type Edges = Edges<'a, E, Ty, Ix>;
     fn edges(self, a: Self::NodeId) -> Self::Edges {
         self.edges(a)
+    }
+}
+
+impl<'a, N, E, Ty, Ix> IntoEdgesDirected for &'a Graph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+{
+    type EdgesDirected = Edges<'a, E, Ty, Ix>;
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected {
+        self.edges_directed(a, dir)
     }
 }
 

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -42,6 +42,7 @@ use visit::{
     EdgeRef,
     IntoNodeReferences,
     IntoEdges,
+    IntoEdgesDirected,
     IntoEdgeReferences,
     NodeIndexable,
 };
@@ -1247,6 +1248,15 @@ impl<'a, N, E, Ty, Ix> IntoEdges for &'a StableGraph<N, E, Ty, Ix>
     }
 }
 
+impl<'a, N, E, Ty, Ix> IntoEdgesDirected for &'a StableGraph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+{
+    type EdgesDirected = Edges<'a, E, Ty, Ix>;
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected {
+        self.edges_directed(a, dir)
+    }
+}
 
 
 /// Iterator over the edges of from or to a node

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -241,6 +241,31 @@ pub trait IntoEdges : IntoEdgeReferences + IntoNeighbors {
 IntoEdges!{delegate_impl []}
 
 trait_template! {
+/// Access to all edges of each node, in the specified direction.
+///
+/// The edges are, depending on the direction and the graph’s edge type:
+///
+///
+/// - `Directed`, `Outgoing`: All edges from `a`.
+/// - `Directed`, `Incoming`: All edges to `a`.
+/// - `Undirected`: All edges connected to `a`.
+///
+/// This is an extended version of the trait `IntoNeighborsDirected`; the former
+/// only iterates over the target node identifiers, while this trait
+/// yields edge references (trait [`EdgeRef`][er]).
+///
+/// [er]: trait.EdgeRef.html
+pub trait IntoEdgesDirected : IntoEdges + IntoNeighborsDirected {
+    @section type
+    type EdgesDirected: Iterator<Item=Self::EdgeRef>;
+    @section self
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected;
+}
+}
+
+IntoEdgesDirected!{delegate_impl []}
+
+trait_template! {
 /// Access to the sequence of the graph’s `NodeId`s.
 pub trait IntoNodeIdentifiers : GraphRef {
     @section type


### PR DESCRIPTION
- Not all possible implementors are ready yet (NodeFiltered is missing,
  needs some extra care, EdgeFiltered a new neighbors iterator,
  GraphMap is missing because it doesn't have the required method).

Fixes #125 cc #176 