### PR TITLE
Add initial dominance_frontiers implementation

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -12,10 +12,13 @@
 //! strictly dominates **B** and there does not exist any node **C** where **A**
 //! dominates **C** and **C** dominates **B**.
 
+
+use std::iter::FromIterator;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
-use visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
+use visit::{DfsPostOrder, GraphBase, IntoNeighbors, IntoNeighborsDirected, Visitable, IntoNodeIdentifiers, VisitMap, Walker};
+use Direction;
 
 /// The dominance relation for some graph and root.
 #[derive(Debug, Clone)]
@@ -75,6 +78,52 @@ impl<N> Dominators<N>
         } else {
             None
         }
+    }
+
+    /// Returns the dominance frontier of every node in `G`.
+    ///
+    /// From Cytron et. al, the dominance frontier is defined as:
+    /// > the set of all cfg nodes, y, such that b dominates a predecessor of y but does not strictly
+    /// > dominate y
+    ///
+    /// We use the algorithm detailed here: https://www.cs.rice.edu/~keith/EMBED/dom.pdf
+    pub fn dominance_frontiers<G>(&self, graph: G) -> HashMap<G::NodeId, Vec<G::NodeId>>
+        where
+        <G as Visitable>::Map: VisitMap<N>,
+        G: IntoNeighborsDirected + IntoNodeIdentifiers + IntoNeighbors + Visitable + GraphBase<NodeId = N>,
+        <G as IntoNeighborsDirected>::NeighborsDirected: Clone,
+        <G as GraphBase>::NodeId: Eq + Hash + Ord {
+        let mut frontiers = HashMap::<G::NodeId, Vec<G::NodeId>>::from_iter(graph.node_identifiers().map(|v| (v, vec![])));
+
+        for node in graph.node_identifiers() {
+            let (predecessors, predecessors_len) = {
+                let ret = graph.neighbors_directed(node, Direction::Incoming);
+                let count = ret.clone().count();
+                (ret, count)
+            };
+
+            if predecessors_len >= 2 {
+                for p in predecessors {
+                    let mut runner = p;
+
+                    match self.immediate_dominator(node) {
+                        Some(dominator) => {
+                            while runner != dominator {
+                                frontiers.entry(runner).or_insert(vec![]).push(node);
+                                runner = self.immediate_dominator(runner).unwrap();
+                            }
+
+                        },
+                        None => ()
+                    }
+                }
+                for (_, frontier) in frontiers.iter_mut() {
+                    frontier.sort();
+                    frontier.dedup();
+                }
+            }
+        }
+        frontiers
     }
 }
 
@@ -243,6 +292,7 @@ fn simple_fast_post_order<G>(graph: G,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use Graph;
 
     #[test]
     fn test_iter_dominators() {
@@ -263,5 +313,44 @@ mod tests {
         assert_eq!(vec![1, 0], strict_doms);
 
         assert_eq!(None::<()>, doms.strict_dominators(99).map(|_| unreachable!()));
+    }
+
+    #[test]
+    fn dominance_frontiers_test () {
+        let mut g = Graph::<usize, ()>::new();
+        let a = g.add_node(0);
+        let b = g.add_node(1);
+        let c = g.add_node(2);
+        let d = g.add_node(3);
+        let e = g.add_node(4);
+        let f = g.add_node(5);
+
+        g.add_edge(a, b, ());
+        g.add_edge(b, c, ());
+        g.add_edge(b, d, ());
+        g.add_edge(c, e, ());
+        g.add_edge(d, e, ());
+        g.add_edge(e, f, ());
+        g.add_edge(a, f, ());
+
+        let dom = simple_fast(&g, a);
+
+        assert_eq!(dom.immediate_dominator(a), None);
+        assert_eq!(dom.immediate_dominator(b).unwrap(), a);
+        assert_eq!(dom.immediate_dominator(c).unwrap(), b);
+        assert_eq!(dom.immediate_dominator(d).unwrap(), b);
+        assert_eq!(dom.immediate_dominator(e).unwrap(), b);
+        assert_eq!(dom.immediate_dominator(f).unwrap(), a);
+
+        let frontiers = dom.dominance_frontiers(&g);
+
+        assert_eq!(frontiers.len(), 6);
+        // TODO: make this return none?
+        assert_eq!(frontiers[&a], vec![]);
+        assert_eq!(frontiers[&b], vec![f]);
+        assert_eq!(frontiers[&c], vec![e]);
+        assert_eq!(frontiers[&d], vec![e]);
+        assert_eq!(frontiers[&e], vec![f]);
+        assert_eq!(frontiers[&f], vec![]);
     }
 }


### PR DESCRIPTION
**WIP**

@bluss need your opinion/recommendation on:

1. The return type of dominance frontiers
2. The signature, e.g., whether:

     a. `dominance_frontiers` should be `dominance_frontier(&self, graph: G, node: G::NodeId) -> DominanceFrontier` (i.e., returns frontier for a given node (ideally the frontier is an iterator)) _OR_,

     b. the current impl `dominance_frontiers(&self, graph: G) -> DominanceFrontiers` which computes the frontier for every node in the graph, given the dominator computation in `&self`

For 1, I don't see an immediately obvious way to return an iterator instead of a vector/set for the frontier; would appreciate any insight you have here.

**EDIT**

For 1b, I tried this initially but I couldn't see how to correctly implement the algorithm as defined in that paper, since frontiers are inserted essentially out of order w.r.t. the current node in the graph node iteration, iiuc.

The algo is here:

```
for all nodes, b
  if the number of predecessors of b ≥ 2
     for all predecessors, p, of b
       runner ← p
       while runner != doms[b]
         add b to runner’s dominance frontier set
         runner = doms[runner]
```