### PR TITLE
added extra variable returned by dijkstra algorithm, shortest path tree

### DIFF
--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -21,7 +21,7 @@ use algo::Measure;
 /// [Generic] Dijkstra's shortest path algorithm.
 ///
 /// Compute the length of the shortest path from `start` to every reachable
-/// node.
+/// node, as well as the shortest path tree.
 ///
 /// The graph should be `Visitable` and implement `IntoEdges`. The function
 /// `edge_cost` should return the cost for a particular edge, which is used
@@ -30,50 +30,72 @@ use algo::Measure;
 /// If `goal` is not `None`, then the algorithm terminates once the `goal` node's
 /// cost is calculated.
 ///
-/// Returns a `HashMap` that maps `NodeId` to path cost.
+/// Returns a tuple containing:
+///
+/// * `HashMap` that maps `NodeId` to path cost. The shortest path weight is the sum of the edge
+/// weights along the shortest path.
+/// * `HashMap` that maps each `NodeId` to its predecessor. The predecessor map records the edges
+/// in the shortest path tree, the tree computed by the traversal of the graph.
+/// Upon completion of the algorithm, the edges *(p[u],u)* for all *u* in *V* are in the tree.
+/// The shortest path from vertex *s* to each vertex *v* in the graph consists of the vertices
+/// *v, p[v], p[p[v]],* and so on until *s* is reached, in reverse order.
+/// The tree is not guaranteed to be a minimum spanning tree. If *p[u]* does not exist, it is
+/// either because u has not been visited as the algorithm
+/// stopped or that it is not reachable from the source.
 pub fn dijkstra<G, F, K>(graph: G, start: G::NodeId, goal: Option<G::NodeId>,
                          mut edge_cost: F)
-    -> HashMap<G::NodeId, K>
+    -> (HashMap<G::NodeId, K>, HashMap<G::NodeId,G::NodeId>)
     where G: IntoEdges + Visitable,
           G::NodeId: Eq + Hash,
           F: FnMut(G::EdgeRef) -> K,
           K: Measure + Copy,
 {
     let mut visited = graph.visit_map();
-    let mut scores = HashMap::new();
-    //let mut predecessor = HashMap::new();
+    let mut scores = HashMap::new(); // distance map, holding the scores
+    let mut predecessor = HashMap::new(); // predecessor map, holding the shortest path tree
     let mut visit_next = BinaryHeap::new();
     let zero_score = K::default();
     scores.insert(start, zero_score);
     visit_next.push(MinScored(zero_score, start));
+    // we iterate over all nodes of the graph
     while let Some(MinScored(node_score, node)) = visit_next.pop() {
+        // if the node has been visited (and then scored), we go the next node to visit
         if visited.is_visited(&node) {
             continue
         }
+        // if the optional goal node has been reached, we terminate the algorithm
         if goal.as_ref() == Some(&node) {
             break
         }
+        // for each node we explore connected nodes
         for edge in graph.edges(node) {
             let next = edge.target();
+            // if the target node has been visited, we continue to explore other nodes
             if visited.is_visited(&next) {
                 continue
             }
-            let mut next_score = node_score + edge_cost(edge);
+            let mut next_score = node_score + edge_cost(edge); // compute the total weight
             match scores.entry(next) {
+                // if there is an existing entry, we see if we need to update it
                 Occupied(ent) => if next_score < *ent.get() {
+                    // the computed weight is lower than the previous one, we update it
+                    // and store the predecessor to record the shortest path tree
                     *ent.into_mut() = next_score;
-                    //predecessor.insert(next.clone(), node.clone());
+                    predecessor.insert(next.clone(), node.clone());
                 } else {
+                    // otherwise we keep the previously computed total weight
+                    // and no need to update the predecessor map
                     next_score = *ent.get();
                 },
+                // if there is no entry, we create one
                 Vacant(ent) => {
                     ent.insert(next_score);
-                    //predecessor.insert(next.clone(), node.clone());
+                    predecessor.insert(next.clone(), node.clone());
                 }
             }
             visit_next.push(MinScored(next_score, next));
         }
         visited.visit(node);
     }
-    scores
+    (scores, predecessor)
 }

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -44,11 +44,17 @@ fn simple() {
 
     // check updated edge weight
     assert_eq!(gr.edge_weight(e, f), Some(&6));
-    let scores = dijkstra(&gr, a, None, |e| *e.weight());
+    let (scores,predecessors) = dijkstra(&gr, a, None, |e| *e.weight());
+    // testing the distance map
     let mut scores: Vec<_> = scores.into_iter().collect();
     scores.sort();
     assert_eq!(scores,
        vec![("A", 0), ("B", 7), ("C", 9), ("D", 11), ("E", 20), ("F", 20)]);
+    // testing the predecessor map
+    let mut predecessors: Vec<_> = predecessors.into_iter().collect();
+    predecessors.sort();
+    assert_eq!(predecessors,
+        vec![("B","A"),("C","A"),("D","C"),("E","D"),("F","C")]);
 }
 
 #[test]


### PR DESCRIPTION
Hi, I added an extra variable returned by dijkstra function, a predecessor map allowing to store the shortest path tree. I basically uncommented the lines with predecessors and updated all the tests. This is modelled on the boost library dijkstra function behaviour.