### PR TITLE
Fix future compat warning with raw pointer casts

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -760,8 +760,8 @@ impl<'b, T> Ord for Ptr<'b, T>
 {
     /// Ptr is ordered by pointer value, i.e. an arbitrary but stable and total order.
     fn cmp(&self, other: &Ptr<'b, T>) -> Ordering {
-        let a = self.0 as *const _;
-        let b = other.0 as *const _;
+        let a: *const T = self.0;
+        let b: *const T = other.0;
         a.cmp(&b)
     }
 }


### PR DESCRIPTION
```
warning: the type of this value must be known in this context
   --> src/graphmap.rs:765:11
    |
765 |         a.cmp(&b)
    |           ^^^
    |
    = note: #[warn(tyvar_behind_raw_pointer)] on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
```