### PR TITLE
Add implementation of `Walker` for `&'a mut W` where `W: Walker`

### DIFF
--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -403,6 +403,15 @@ impl<W, C> Iterator for WalkerIter<W, C>
     }
 }
 
+impl<'a, G, W> Walker<G> for &'a mut W
+    where W: Walker<G> + ?Sized,
+{
+    type Item = W::Item;
+    fn walk_next(&mut self, context: G) -> Option<Self::Item> {
+        (*self).walk_next(context)
+    }
+}
+
 impl<G> Walker<G> for Dfs<G::NodeId, G::Map>
     where G: IntoNeighbors + Visitable
 {


### PR DESCRIPTION
I just came across the desire for this working on a geometry graph
downstream that uses daggy. This is akin to the `Iterator`
implementation for `&'a mut I` where `I: Iterator`.