### PR TITLE
Support more escape codes inside labels 

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -29,7 +29,7 @@ use visit::{GraphRef};
 /// println!("{:?}", Dot::with_config(&graph, &[Config::EdgeNoLabel]));
 ///
 /// // In this case the output looks like this:
-/// // 
+/// //
 /// // digraph {
 /// //     0 [label="\"A\""]
 /// //     1 [label="\"B\""]
@@ -171,10 +171,10 @@ impl<W> fmt::Write for Escaper<W>
 
     fn write_char(&mut self, c: char) -> fmt::Result {
         match c {
-            '"' => try!(self.0.write_char('\\')),
+            '"' | '\\' => try!(self.0.write_char('\\')),
             // \l is for left justified linebreak
-            '\n' => return self.0.write_str(r#"\l"#),
-            _   => { }
+            '\n' => return self.0.write_str("\\l"),
+            _ => {}
         }
         self.0.write_char(c)
     }
@@ -188,7 +188,7 @@ impl<T> fmt::Display for Escaped<T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
-            write!(&mut Escaper(f), "{:#}\\l", &self.0)
+            write!(&mut Escaper(f), "{:#}\n", &self.0)
         } else {
             write!(&mut Escaper(f), "{}", &self.0)
         }
@@ -204,4 +204,14 @@ impl<T> fmt::Display for DebugFmt<T>
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+#[test]
+fn test_escape() {
+    let mut buff = String::new();
+    {
+        let mut e = Escaper(&mut buff);
+        let _ = e.write_str("\" \\ \n");
+    }
+    assert_eq!(buff, "\\\" \\\\ \\l");
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1420,12 +1420,13 @@ fn dot() {
         b: &'static str,
     };
     let mut gr = Graph::new();
-    let a = gr.add_node(Record { a: 1, b: "abc" });
+    let a = gr.add_node(Record { a: 1, b: r"abc\" });
     gr.add_edge(a, a, (1, 2));
     let dot_output = format!("{:#?}", Dot::new(&gr));
     assert_eq!(dot_output,
+    // The single \ turns into four \\\\ because of Debug which turns it to \\ and then escaping each \ to \\.
 r#"digraph {
-    0 [label="Record {\l    a: 1,\l    b: \"abc\"\l}\l"]
+    0 [label="Record {\l    a: 1,\l    b: \"abc\\\\\"\l}\l"]
     0 -> 0 [label="(\l    1,\l    2\l)\l"]
 }
 "#);
@@ -1711,7 +1712,7 @@ fn test_dominators_simple_fast() {
     // http://www.cs.princeton.edu/courses/archive/spr03/cs423/download/dominators.pdf.
 
     let mut graph = DiGraph::<_, _>::new();
-    
+
     let r = graph.add_node("r");
     let a = graph.add_node("a");
     let b = graph.add_node("b");


### PR DESCRIPTION
Fix for #214 

Now escapes `|`, `&`, `<`, `>` and `\`. Turned out to be a bit more tricky than I anticipated, but it's all good now.