### PR TITLE
Fix conflict with now-stable method Iterator::find_map

### DIFF
--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1168,7 +1168,7 @@ impl<'a, N, Ix> Iterator for NodeReferences<'a, N, Ix>
     type Item = (NodeIndex<Ix>, &'a N);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.find_map(|(i, node)| {
+        self.iter.ex_find_map(|(i, node)| {
             node.weight.as_ref().map(move |w| (node_index(i), w))
         })
     }
@@ -1183,7 +1183,7 @@ impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
     where Ix: IndexType
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.rfind_map(|(i, node)| {
+        self.iter.ex_rfind_map(|(i, node)| {
             node.weight.as_ref().map(move |w| (node_index(i), w))
         })
     }
@@ -1360,7 +1360,7 @@ impl<'a, E, Ix> Iterator for EdgeReferences<'a, E, Ix>
     type Item = EdgeReference<'a, E, Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.find_map(|(i, edge)|
+        self.iter.ex_find_map(|(i, edge)|
             edge.weight.as_ref().map(move |weight| {
                 EdgeReference {
                     index: edge_index(i),
@@ -1375,7 +1375,7 @@ impl<'a, E, Ix> DoubleEndedIterator for EdgeReferences<'a, E, Ix>
     where Ix: IndexType
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.rfind_map(|(i, edge)|
+        self.iter.ex_rfind_map(|(i, edge)|
             edge.weight.as_ref().map(move |weight| {
                 EdgeReference {
                     index: edge_index(i),
@@ -1524,7 +1524,7 @@ impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
     type Item = NodeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.find_map(|(i, node)| {
+        self.iter.ex_find_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(node_index(i))
             } else { None }
@@ -1539,7 +1539,7 @@ impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
 
 impl<'a, N, Ix: IndexType> DoubleEndedIterator for NodeIndices<'a, N, Ix> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.rfind_map(|(i, node)| {
+        self.iter.ex_rfind_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(node_index(i))
             } else { None }
@@ -1570,7 +1570,7 @@ impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
     type Item = EdgeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.find_map(|(i, node)| {
+        self.iter.ex_find_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(edge_index(i))
             } else { None }
@@ -1585,7 +1585,7 @@ impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
 
 impl<'a, E, Ix: IndexType> DoubleEndedIterator for EdgeIndices<'a, E, Ix> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.rfind_map(|(i, node)| {
+        self.iter.ex_rfind_map(|(i, node)| {
             if node.weight.is_some() {
                 Some(edge_index(i))
             } else { None }

--- a/src/iter_utils.rs
+++ b/src/iter_utils.rs
@@ -2,7 +2,7 @@
 pub trait IterUtilsExt : Iterator {
     /// Return the first element that maps to `Some(_)`, or None if the iterator
     /// was exhausted.
-    fn find_map<F, R>(&mut self, mut f: F) -> Option<R>
+    fn ex_find_map<F, R>(&mut self, mut f: F) -> Option<R>
         where F: FnMut(Self::Item) -> Option<R>
     {
         for elt in self {
@@ -15,7 +15,7 @@ pub trait IterUtilsExt : Iterator {
 
     /// Return the last element from the back that maps to `Some(_)`, or
     /// None if the iterator was exhausted.
-    fn rfind_map<F, R>(&mut self, mut f: F) -> Option<R>
+    fn ex_rfind_map<F, R>(&mut self, mut f: F) -> Option<R>
         where F: FnMut(Self::Item) -> Option<R>,
               Self: DoubleEndedIterator,
     {


### PR DESCRIPTION
To quick fix this without changing rust version, rename our local
extension methods to use an ex_ prefix.

Fixes #223