### PR TITLE
Add missing impl to EdgeIndex

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -158,6 +158,10 @@ impl<Ix: IndexType> EdgeIndex<Ix>
     }
 }
 
+impl<Ix: IndexType> From<Ix> for EdgeIndex<Ix> {
+    fn from(ix: Ix) -> Self { EdgeIndex(ix) }
+}
+
 impl<Ix: fmt::Debug> fmt::Debug for EdgeIndex<Ix>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
`NodeIndex` in `Graph` has the following trait impl:
```rust
impl<Ix: IndexType> From<Ix> for NodeIndex<Ix> {
    fn from(ix: Ix) -> Self { NodeIndex(ix) }
}
```

This PR adds the same `impl From<Ix>` to `EdgeIndex`, which it did not have.