### PR TITLE
Don't suggest use of usize instead of u32

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -303,7 +303,7 @@ impl<E, Ix: IndexType> Edge<E, Ix>
 /// take its place. Similarly, removing an edge shifts the index of the last edge.
 ///
 /// The `Ix` parameter is `u32` by default. The goal is that you can ignore this parameter
-/// completely unless you need a very big graph -- then you can use `usize`.
+/// completely unless you need a very big graph -- then you can use `u64` or `u128`.
 ///
 /// ### Pros and Cons of Indices
 ///


### PR DESCRIPTION
usize machine dependent and on x86 machines it is the same as `u32`. Instead use a machine independent size e.g. `u64` or `u128`.