### PR TITLE
Add minimum weight feedback arc set (MWFAS) approximation algorithm for StableGraph

### DIFF
--- a/benches/stable_graph.rs
+++ b/benches/stable_graph.rs
@@ -126,6 +126,16 @@ fn sccs_graph(bench: &mut Bencher)
     bench.iter(|| petgraph::algo::kosaraju_scc(&a));
 }
 
+// Ideally, we wouldn't clone inside the benched function, but it's a
+// negligible part of its runtime (< 1%)
+#[bench]
+fn compute_fas(bench: &mut Bencher) {
+    let g = parse_stable_graph::<Directed>(BIGGER);
+    bench.iter(|| {
+        g.clone().approximate_fas(|_| 1usize);
+    });
+}
+
 /// Parse a text adjacency matrix format into a directed graph
 fn parse_stable_graph<Ty: EdgeType>(s: &str) -> StableGraph<(), (), Ty>
 {

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -9,7 +9,7 @@ use std::iter;
 use std::marker::PhantomData;
 use std::mem::replace;
 use std::mem::size_of;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Sub, Add};
 use std::slice;
 
 use {
@@ -41,10 +41,13 @@ use IntoWeightedEdge;
 use visit::{
     EdgeRef,
     IntoNodeReferences,
+    IntoNodeIdentifiers,
     IntoEdges,
     IntoEdgesDirected,
     IntoEdgeReferences,
     NodeIndexable,
+    Visitable,
+    VisitMap,
 };
 
 // reexport those things that are shared with Graph
@@ -912,6 +915,154 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
         }
     }
 
+    /// Compute an approximation to the minimum cost feedback arc set (FAS).
+    /// 
+    /// This method is *destructive* and will remove edges from the input graph.
+    /// In particular, the graph will be acyclic after calling it.
+    ///
+    /// Returns the feedback arc set as a vector.
+    ///
+    /// # Example
+    /// ```
+    /// use petgraph::stable_graph::StableGraph;
+    ///
+    /// let mut g = StableGraph::new();
+    /// let a = g.add_node(());
+    /// let b = g.add_node(());
+    /// let c = g.add_node(());
+    /// let d = g.add_node(());
+    /// let e = g.add_node(());
+    /// let f = g.add_node(());
+    /// g.extend_with_edges(&[
+    ///     (b, a, 4.0),
+    ///     (a, d, 2.0),
+    ///     (b, c, 2.0),
+    ///     (f, b, 7.0),
+    ///     (c, e, 5.0),
+    ///     (e, f, 3.0),
+    ///     (d, e, 3.0),
+    /// ]);
+    ///
+    /// // Graph represented with the weight of each edge
+    /// //
+    /// //     4       2
+    /// // a <---- b ----> c
+    /// // v 2     ^ 7     |
+    /// // d       f       | 5
+    /// // | 3     ^ 3     |
+    /// // \-----> e <-----/
+    ///
+    /// let fas = g.approximate_fas(|e| *e.weight());
+    /// assert_eq!(vec![(e, f, 3.0)], fas);
+    /// ```
+    ///
+    /// **Reference**
+    ///
+    /// * Camil Demetrescu, Irene Finocchi;
+    ///   *[Combinatorial Algorithms for Feedback Problems in Directed Graphs](http://wwwusers.di.uniroma1.it/~finocchi/papers/FAS.pdf)*
+    pub fn approximate_fas<F, K>(
+        &mut self,
+        mut edge_cost: F,
+    ) -> Vec<(NodeIndex<Ix>, NodeIndex<Ix>, E)>
+    where
+        F: FnMut(EdgeReference<E, Ix>) -> K,
+        K: Default + Copy + PartialOrd + Sub<K, Output = K> + Add<K, Output = K>,
+    {
+        let zero_weight = <K as Default>::default();
+
+        let mut arc_set = Vec::new();
+        let mut predecessor = vec![None; self.node_bound()];
+        let mut edge_cost_reduction = vec![zero_weight; self.edge_bound()];
+        let mut cycle = Vec::new();
+        let mut discovered = self.visit_map();
+        let mut finished = self.visit_map();
+
+        // keep cycles until there are none left by removing one of their edges
+        loop {
+            // FIXME: this unsafe block shouldn't be necessary. im sure our borrow is sound
+            let borrow: &Self = unsafe { ::std::mem::transmute(&*self) };
+            discovered.as_mut_slice().copy_from_slice(finished.as_slice());
+
+            let lowest_cost =
+                borrow
+                .node_identifiers()
+                .filter_map(|start| borrow.find_cycle_arc(&mut predecessor, &mut discovered, &mut finished, start))
+                .next()
+                .map(|e| {
+                    let orig_edge_cost = edge_cost(e);
+                    let mut min_weight = orig_edge_cost - edge_cost_reduction[e.id().index()];
+                    let mut pred = e;
+
+                    cycle.clear();
+                    cycle.push((e.id(), orig_edge_cost));
+
+                    while e.target() != pred.source() {
+                        pred = predecessor[pred.source().index()].unwrap();
+                        let orig_edge_cost = edge_cost(pred);
+                        let edge_weight = orig_edge_cost - edge_cost_reduction[pred.id().index()];
+                        cycle.push((pred.id(), orig_edge_cost));
+
+                        if edge_weight < min_weight {
+                            min_weight = edge_weight;
+                        }
+                    }
+
+                    min_weight
+                });
+
+            if let Some(min_weight) = lowest_cost {
+                let mut removable = true;
+
+                // update the weights of all arcs in the cycle and remove the
+                // first one that hits zero
+                for &(edge_id, orig_edge_cost) in &cycle {
+                    let idx = edge_id.index();
+                    let cost_reduction = edge_cost_reduction[idx] + min_weight;
+                    edge_cost_reduction[idx] = cost_reduction;
+
+                    if removable && orig_edge_cost - cost_reduction <= zero_weight {
+                        let edge_endpoints = self.edge_endpoints(edge_id).unwrap();
+                        let w = self.remove_edge(edge_id).unwrap();
+                        arc_set.push((edge_endpoints.0, edge_endpoints.1, w, orig_edge_cost));
+                        removable = false;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        let arc_set_len = arc_set.len();
+        let mut result_set = Vec::with_capacity(arc_set_len);
+        
+        // always include the last edge, since re-adding that
+        // will always introduce a cycle
+        if let Some((start, end, w, _edge_cost)) = arc_set.pop() {
+            result_set.push((start, end, w));
+        }
+
+        // sorting arc_set by decreasing cost in order to re-introduce
+        // the heaviest edges first
+        arc_set.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(cmp::Ordering::Equal));
+
+        // try to re-add edges without introducing cycles
+        for (start, end, w, _edge_cost) in arc_set {
+            // FIXME: again, this transmute shouldnt be necessary i think
+            let borrow: &Self = unsafe { ::std::mem::transmute(&*self) };
+            let edge_id = self.add_edge(start, end, w);
+
+            discovered.clear();
+            finished.clear();
+
+            if borrow.find_cycle_arc(&mut predecessor, &mut discovered, &mut finished, start).is_some() {
+                let w = self.remove_edge(edge_id).unwrap();
+                result_set.push((start, end, w));
+            }
+        }
+
+        result_set
+    }
+
     //
     // internal methods
     //
@@ -927,6 +1078,39 @@ impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
         self.edge_references()
             .next_back()
             .map_or(0, |edge| edge.id().index() + 1)
+    }
+
+    /// Returns a reference to an edge in a cycle, keeping track of all
+    /// predecessors, discovered nodes and finished nodes
+    fn find_cycle_arc<'g>(&'g self,
+        predecessor: &mut Vec<Option<EdgeReference<'g, E, Ix>>>,
+        discovered: &mut <Self as Visitable>::Map,
+        finished: &mut <Self as Visitable>::Map,
+        start: NodeIndex<Ix>
+    ) -> Option<EdgeReference<'g, E, Ix>>
+        where Ix: IndexType
+    {
+        if !discovered.visit(start) {
+            return None;
+        }
+
+        for e in self.edges(start) {
+            let v = e.target();
+
+            if !discovered.is_visited(&v) {
+                predecessor[v.index()] = Some(e);
+                
+                if let Some(e2) = self.find_cycle_arc(predecessor, discovered, finished, v) {
+                    return Some(e2);
+                }
+            } else if !finished.is_visited(&v) {
+                return Some(e);
+            }
+        }
+
+        finished.visit(start);
+
+        None
     }
 
     #[cfg(feature = "serde-1")]

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -528,6 +528,20 @@ fn graph_condensation_acyclic() {
     quickcheck::quickcheck(prop as fn(_) -> bool);
 }
 
+#[test]
+fn removed_fas_is_acyclic() {
+    fn prop(mut g: StableDiGraph<u32, u32>) -> bool {
+        let mut clone = g.clone();
+        let fas = clone.approximate_fas(|e| *e.weight());
+        for e in fas {
+            let edge = g.find_edge(e.0, e.1).unwrap();
+            g.remove_edge(edge);
+        }
+        !is_cyclic_directed(&g) && !is_cyclic_directed(&clone)
+    }
+    quickcheck::quickcheck(prop as fn(_) -> bool);
+}
+
 #[derive(Debug, Clone)]
 struct DAG<N: Default + Clone + Send + 'static>(Graph<N, ()>);
 


### PR DESCRIPTION
This pull request implements an approximate minimum weight feedback set algorithm for `StableGraph`.

## Motivation

I have a use case where I want to perform a topological sort on a digraph which is slightly noisy and can contain cycles. By removing a minimum weight feedback arc set, one can remove cycles with the smallest 'impact' to the original graph.

## Algorithm details

Computing a minimum (weight) feedback arc set is [NP-hard](https://en.wikipedia.org/wiki/Feedback_arc_set#Minimum_feedback_arc_set) and solving it optimally is therefore usually infeasible. This pull request implements the algorithm laid out in [this paper](http://wwwusers.di.uniroma1.it/~finocchi/papers/FAS.pdf). Its worst case runtime is O(nm), where n and m are the number of vertices and edges respectively. From my preliminary tests, it behaves similar to the popular MWFAS algorithm by [Eades et al](https://pdfs.semanticscholar.org/c7ed/d9acce96ca357876540e19664eb9d976637f.pdf), both in solution quality as in runtime.

## Implementation details

Ideally, this algorithm would've been implemented generically over all graph types supporting the right operations. This was my approach initially, but quickly discovered that index stability with respect to edge removal is essential for a performant implementation, since we're repeatedly removing edges and need to keep references to remaining edges. This rules out almost all other graph types. Further, removing edges does not yet seem to be captured in a trait yet.

There are two unsafe blocks in this implementation, both of which exist to transmute a mutable reference to an immutable one. I am absolutely convinced that these operations should be sound, but I was not able to satisfy the borrow checker. If any one is able to help me get rid of these, I would forever grateful.

## Considerations

I am not sure whether this algorithm belongs in this crate. Because the implementation isn't generic, its application may be limited. Also, I believe it would be the first algorithm which doesn't return an exact solution. Finally, I am acutely aware that this project has limited maintainer bandwidth - adding extra surface area may not be desirable. On that point, I would be happy to join the petgraph team to maintain this and other algorithms.