### PR TITLE
Fix bug where Csr::add_node adds existing edges to new node

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -937,4 +937,25 @@ mod tests {
 
         assert_eq!(g.edge_count(), 3);
     }
+
+    #[test]
+    fn test_add_node_with_existing_edges() {
+        let mut g: Csr = Csr::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+
+        assert!(g.add_edge(a, b, ()));
+
+        let c = g.add_node(());
+
+        println!("{:?}", g);
+
+        assert_eq!(g.node_count(), 3);
+
+        assert_eq!(g.neighbors_slice(a), &[b]);
+        assert_eq!(g.neighbors_slice(b), &[]);
+        assert_eq!(g.neighbors_slice(c), &[]);
+
+        assert_eq!(g.edge_count(), 1);
+    }
 }

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -269,7 +269,7 @@ impl<N, E, Ty, Ix> Csr<N, E, Ty, Ix>
     /// Adds a new node with the given weight, returning the corresponding node index.
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         let i = self.row.len() - 1;
-        self.row.insert(i, 0);
+        self.row.insert(i, self.column.len());
         self.node_weights.insert(i, weight);
         Ix::new(i)
     }


### PR DESCRIPTION
`add_node` used 0 as column offset, causing all existing edges to be added to the new node.