### PR TITLE
Remove Travis support for 1.15, bump minimum to 1.25.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: rust
 sudo: false
 matrix:
   include:
-    - rust: 1.15.0
-      env:
-      - ALL=' '
     - rust: 1.25.0
       env:
       - ALL=' '

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 petgraph
 ========
 
-Graph data structure library. Requires Rust 1.12.
+Graph data structure library. Requires Rust 1.25 or later.
 
 Please read the `API documentation here`__
 


### PR DESCRIPTION
Dependencies haven't built on Travis in some time for Rust 1.15.

Adjust the claimed minimum version to 1.25 which is what Travis
has been testing successfully.